### PR TITLE
Remove email addresses from markdown files and fix user guide link

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,22 +16,22 @@ the License.
 
 ### Author
 
-The LinkedIn Gradle Plugin for Apache Hadoop was designed and created by Alex Bain
-(abain@linkedin.com). The design of the LinkedIn Gradle DSL for Apache Hadoop was influenced by
+The LinkedIn Gradle Plugin for Apache Hadoop was designed and created by Alex Bain. The design of
+the LinkedIn Gradle DSL for Apache Hadoop was influenced by
 [azkaban-rb](https://github.com/matthayes/azkaban-rb) from Matthew Hayes and by input from Will
 Vaughan.
 
 ### Contributors
 
-The following were contributed by Anant Nag (annag@linkedin.com). Thanks, Anant!
+The following were contributed by Anant Nag. Thanks, Anant!
 * `HADOOP-12726 Style cleanups for Hadoop zip tests`
 * `HADOOP-12243 Fix Hadoop Plugin PCL Breakage`
 * `HADOOP-10148 Support exclusion list for Hadoop Plugin sources Zip`
 
-The following were contributed by Akshay Rai (akrai@linkedin.com). Thanks, Akshay!
+The following were contributed by Akshay Rai. Thanks, Akshay!
 * `HADOOP-12243 Fix Hadoop Plugin PCL Breakage`
 * `HADOOP-10773 Rewrite li-azkaban2 zip upload tasks for the Hadoop Plugin`
 * `HADOOP-8251 Hadoop DSL doesn't use -p flag for mkdir`
 
-The following were contributed by Keith Dsouza (kdsouza@linkedin.com). Thanks, Keith!
+The following were contributed by Keith Dsouza. Thanks, Keith!
 * `Added support to the KafkaPushJob to accept the disable.auditing property`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ schedulers like Azkaban and Apache Oozie.
 
 #### Hadoop Plugin User Guide
 
-The Hadoop Plugin User Guide is available at [Hadoop Plugin User Guide]
+The Hadoop Plugin User Guide is available at [User Guide]
 (https://github.com/linkedin/linkedin-gradle-plugin-for-apache-hadoop/wiki/User-Guide).
 
 #### Hadoop DSL Language Reference


### PR DESCRIPTION
Remove email addresses so contributors don't get spammed.
