### PR TITLE
LIHADOOP-13136 Hadoop Plugin zip extension fixes for CRT compatibility

### DIFF
--- a/hadoop-plugin-test/src/main/gradle/positive/azkabanZip.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/azkabanZip.gradle
@@ -25,14 +25,14 @@ hadoopZip {
     }
   }
 
-  cluster("magic") {
+  zip("magic") {
     from("src") {
       into "src"
       include "main/**/**"
     }
   }
 
-  cluster("canasta") {
+  zip("canasta") {
     from("src") { }
   }
 

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/scm/HadoopZipExtension.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/scm/HadoopZipExtension.groovy
@@ -37,18 +37,19 @@ import org.gradle.api.file.CopySpec;
  */
 public class HadoopZipExtension {
   CopySpec baseCopySpec;
-  Map<String, CopySpec> clusterMap;
   String libPath;
   Project project;
+  Map<String, CopySpec> zipMap;
 
   /**
-   * Constructor for the HadoopZipExtension
-   * @param project
+   * Constructor for the HadoopZipExtension.
+   *
+   * @param project The Gradle project
    */
   HadoopZipExtension(Project project) {
     this.project = project;
-    clusterMap = new HashMap<String, CopySpec>();
     libPath = ".";
+    zipMap = new HashMap<String, CopySpec>();
   }
 
   /**
@@ -62,13 +63,13 @@ public class HadoopZipExtension {
    *       }
    *     }
    *
-   *     cluster("magic") {
+   *     zip("magic") {
    *       from ("src/") {
    *         into "src"
    *       }
    *     }
    *
-   *     cluster("canasta") {
+   *     zip("canasta") {
    *       from ("azkaban/") {
    *         into "."
    *       }
@@ -87,31 +88,6 @@ public class HadoopZipExtension {
   /**
    * <pre>
    *   hadoopZip {
-   *     cluster("magic") {
-   *       from ("src/") {
-   *         into "src"
-   *       }
-   *     }
-   *
-   *     cluster("canasta") {
-   *       from ("src/") {
-   *         into "src"
-   *       }
-   *     }
-   *   }
-   * </pre>
-   * The DSL inside the {@code cluster(clustername)\{} } block is the same DSL used for Copy tasks.
-   */
-  void cluster(String name, Closure closure) {
-    if (clusterMap.containsKey(name)){
-      throw new RuntimeException("${name} is already defined");
-    }
-    clusterMap.put(name, project.copySpec(closure));
-  }
-
-  /**
-   * <pre>
-   *   hadoopZip {
    *     main {
    *       from ("src/") {
    *         into "src"
@@ -122,7 +98,32 @@ public class HadoopZipExtension {
    * The DSL inside the {@code main\{} } block is the same DSL used for Copy tasks.
    */
   void main(Closure closure) {
-    cluster("main", closure);
+    zip("main", closure);
+  }
+
+  /**
+   * <pre>
+   *   hadoopZip {
+   *     zip("magic") {
+   *       from ("src/") {
+   *         into "src"
+   *       }
+   *     }
+   *
+   *     zip("canasta") {
+   *       from ("src/") {
+   *         into "src"
+   *       }
+   *     }
+   *   }
+   * </pre>
+   * The DSL inside the {@code zip(zipName)\{} } block is the same DSL used for Copy tasks.
+   */
+  void zip(String zipName, Closure closure) {
+    if (zipMap.containsKey(zipName)){
+      throw new RuntimeException("${zipName} is already defined");
+    }
+    zipMap.put(zipName, project.copySpec(closure));
   }
 
   /**
@@ -135,24 +136,24 @@ public class HadoopZipExtension {
   }
 
   /**
-   * Utility method to return the CopySpec for the given cluster name.
+   * Utility method to return the CopySpec for the given named zip.
    *
-   * @param clusterName
-   * @return Returns the CopySpec for the given cluster name
+   * @param zipName
+   * @return Returns the CopySpec for the given zip name
    */
-  CopySpec getClusterCopySpec(String clusterName) {
-    if (clusterMap.containsKey(clusterName)) {
-      return clusterMap.get(clusterName);
+  CopySpec getZipCopySpec(String zipName) {
+    if (zipMap.containsKey(zipName)) {
+      return zipMap.get(zipName);
     }
     return null;
   }
 
   /**
-   * Utility method to return the clusterMap.
+   * Utility method to return the zipMap.
    *
-   * @return Returns the clusterMap
+   * @return Returns the zipMap
    */
-  Map<String, CopySpec> getClusterMap() {
-    return clusterMap;
+  Map<String, CopySpec> getZipMap() {
+    return zipMap;
   }
 }

--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/scm/AzkabanZipTest.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/scm/AzkabanZipTest.groovy
@@ -32,12 +32,12 @@ public class AzkabanZipTest {
   private Closure baseClosure;
   private File azkabanLibDirectory;
   private Configuration azkabanRuntime;
-  private String clustername;
+  private String zipName;
   String zipPath;
 
   @Before
   public void setup() {
-    clustername = "magic";
+    zipName = "magic";
     project = ProjectBuilder.builder().build();
     project.apply plugin: 'distribution';
     plugin = new ScmPluginTest();
@@ -122,7 +122,7 @@ public class AzkabanZipTest {
     project.getRootProject().tasks["buildSourceZip"].execute();
     zipPath = project.getRootProject().tasks["buildSourceZip"].archivePath.path;
 
-    def task = project.getTasksByName("${clustername}HadoopZip", false);
+    def task = project.getTasksByName("${zipName}HadoopZip", false);
     def zipTask = task.iterator().next();
     zipTask.execute();
 
@@ -146,7 +146,7 @@ public class AzkabanZipTest {
     project.getRootProject().tasks["buildSourceZip"].execute();
     zipPath = project.getRootProject().tasks["buildSourceZip"].archivePath.path;
 
-    def task = project.getTasksByName("${clustername}HadoopZip", false);
+    def task = project.getTasksByName("${zipName}HadoopZip", false);
     def zipTask = task.iterator().next();
     zipTask.execute();
 
@@ -178,7 +178,7 @@ public class AzkabanZipTest {
     project.getRootProject().tasks["buildSourceZip"].execute();
     zipPath = project.getRootProject().tasks["buildSourceZip"].archivePath.path;
 
-    def task = project.getTasksByName("${clustername}HadoopZip", false);
+    def task = project.getTasksByName("${zipName}HadoopZip", false);
     def zipTask = task.iterator().next();
     zipTask.execute();
 
@@ -232,7 +232,7 @@ public class AzkabanZipTest {
     project.getRootProject().tasks["buildSourceZip"].execute();
     zipPath = project.getRootProject().tasks["buildSourceZip"].archivePath.path;
 
-    def task = project.getTasksByName("${clustername}HadoopZip", false);
+    def task = project.getTasksByName("${zipName}HadoopZip", false);
     def zipTask = task.iterator().next();
     zipTask.execute();
 
@@ -291,7 +291,7 @@ public class AzkabanZipTest {
     project.getRootProject().tasks["buildSourceZip"].execute();
     zipPath = project.getRootProject().tasks["buildSourceZip"].archivePath.path;
 
-    def task = project.getTasksByName("${clustername}HadoopZip", false);
+    def task = project.getTasksByName("${zipName}HadoopZip", false);
     def zipTask = task.iterator().next();
     zipTask.execute();
 
@@ -371,7 +371,7 @@ public class AzkabanZipTest {
     project.getRootProject().tasks["buildSourceZip"].execute();
     zipPath = project.getRootProject().tasks["buildSourceZip"].archivePath.path;
 
-    def task = project.getTasksByName("${clustername}HadoopZip", false);
+    def task = project.getTasksByName("${zipName}HadoopZip", false);
     def zipTask = task.iterator().next();
     zipTask.execute();
 
@@ -391,20 +391,20 @@ public class AzkabanZipTest {
     }
 
     @Override
-    public CopySpec getClusterCopySpec(String cluster) {
+    public CopySpec getBaseCopySpec() {
+      return project.copySpec(baseClosure);
+    }
+
+    @Override
+    public CopySpec getZipCopySpec(String zipName) {
       return project.copySpec(closure);
     }
 
     @Override
-    public Map<String, CopySpec> getClusterMap() {
-      Map<String, CopySpec> clusterMap = new HashMap<String,CopySpec>();
-      clusterMap.put(clustername, project.copySpec(closure));
-      return clusterMap;
-    }
-
-    @Override
-    public CopySpec getBaseCopySpec() {
-      return project.copySpec(baseClosure);
+    public Map<String, CopySpec> getZipMap() {
+      Map<String, CopySpec> map = new HashMap<String, CopySpec>();
+      map.put(zipName, project.copySpec(closure));
+      return map;
     }
   }
 
@@ -424,7 +424,6 @@ public class AzkabanZipTest {
 
     @Override
     String getSourceZipFilePath(Project project) {
-      project.logger.lifecycle("called ${zipPath}");
       return zipPath;
     }
   }

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liscm/LiHadoopZipExtension.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liscm/LiHadoopZipExtension.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.gradle.liscm;
+
+import com.linkedin.gradle.scm.HadoopZipExtension;
+
+import org.gradle.api.Project;
+import org.gradle.api.file.CopySpec
+
+/**
+ * LinkedIn-specific customizations to the HadoopZipExtension class. In particular, this class
+ * enables users to declare that they should generate a CRT deployment zip that contains their .crt
+ * file. This is particular to LinkedIn and required for LinkedIn's one-click deployment system.
+ */
+class LiHadoopZipExtension extends HadoopZipExtension {
+  boolean declaresCRT = false;
+  boolean declaresMain = false;
+
+  /**
+   * Constructor for the LiHadoopZipExtension.
+   *
+   * @param project The Gradle project
+   */
+  LiHadoopZipExtension(Project project) {
+    super(project);
+  }
+
+  /**
+   * <pre>
+   *   hadoopZip {
+   *     CRT { }
+   *   }
+   * </pre>
+   */
+  void CRT(Closure closure) {
+    if (declaresMain) {
+      throw new Exception("You cannot declare both a main zip and a CRT zip. Refer to go/HadoopCRT for more information.");
+    }
+    declaresCRT = true;
+  }
+
+  /**
+   * <pre>
+   *   hadoopZip {
+   *     main {
+   *       from ("src/") {
+   *         into "src"
+   *       }
+   *     }
+   *   }
+   * </pre>
+   * The DSL inside the {@code main\{} } block is the same DSL used for Copy tasks.
+   */
+  @Override
+  void main(Closure closure) {
+    if (declaresCRT) {
+      throw new Exception("You cannot declare both a main zip and a CRT zip. Refer to go/HadoopCRT for more information.");
+    }
+    declaresMain = true;
+    super.main(closure);
+  }
+
+  /**
+   * <pre>
+   *   hadoopZip {
+   *     zip("magic") {
+   *       from ("src/") {
+   *         into "src"
+   *       }
+   *     }
+   *
+   *     zip("canasta") {
+   *       from ("src/") {
+   *         into "src"
+   *       }
+   *     }
+   *   }
+   * </pre>
+   * The DSL inside the {@code zip(zipName)\{} } block is the same DSL used for Copy tasks.
+   */
+  @Override
+  void zip(String zipName, Closure closure) {
+    if ("CRT".equals(zipName)) {
+      throw new Exception("You cannot declare a zip called CRT. Use the CRT method to declare that your project uses CRT. Refer to go/HadoopCRT for more information.");
+    }
+    super.zip(zipName, closure);
+  }
+}

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liscm/LiScmPlugin.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liscm/LiScmPlugin.groovy
@@ -15,7 +15,10 @@
  */
 package com.linkedin.gradle.liscm;
 
+import com.linkedin.gradle.scm.HadoopZipExtension;
 import com.linkedin.gradle.scm.ScmPlugin;
+
+import org.apache.tools.ant.filters.ReplaceTokens;
 
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -64,6 +67,13 @@ class LiScmPlugin extends ScmPlugin {
         }
       }
     }
+
+    project.afterEvaluate {
+      LiHadoopZipExtension zipExtension = (LiHadoopZipExtension)hadoopZipExtension;
+      if (zipExtension.declaresCRT) {
+        createDeploymentZipTask(project);
+      }
+    }
   }
 
   /**
@@ -77,5 +87,77 @@ class LiScmPlugin extends ScmPlugin {
     List<String> excludeList = super.buildExcludeList(project);
     excludeList.add("ligradle");
     return excludeList;
+  }
+
+  /**
+   * Helper method to create the Hadoop zip extension. Having this method allows for the unit tests
+   * to override it.
+   *
+   * @param project The Gradle project
+   * @return The Hadoop zip extension
+   */
+  @Override
+  HadoopZipExtension createZipExtension(Project project) {
+    LiHadoopZipExtension extension = new LiHadoopZipExtension(project);
+    project.extensions.add("hadoopZip", extension);
+    return extension;
+  }
+
+  /**
+   * Creates a zip archive that contains the .crt file and is setup correctly to work with CRT. CRT
+   * has a couple of weird bugs. To be able to deploy from CRT, there must be:
+   *
+   * 1. An "artifact": line in the artifact-spec.json for this project. This is required by mint
+   *    deploy and crt deploy.
+   *
+   * 2. An artifact in Artifactory with no classifier in the file name, i.e. the entry must be of
+   *    the form: ${project.name}-${project.version}.zip.
+   *
+   * The Tools Python code explicitly tries to form this name as a part of the URL it downloads,
+   * since it assumes you want to deploy the project artifact, rather than something with a
+   * classifier in the name. Thus if you "artifact" line in the artifact-spec.json for your project
+   * is ${project.name}-${project.version}-azkaban.zip, it won't work!
+   *
+   * To work around these problems, we'll give the CRT zip the special "defaultArtifact"
+   * classifier. When the Tools Python code constructs the artifact-spec, it will explicitly use an
+   * artifact with this classifier in the "artifact" line. This accomplishes #1 above.
+   *
+   * Then we'll explicitly set the archiveName property on the zip so that it has the right form.
+   * This accomplishes #2 above. These two together produce the artifacts and an artifact-spec.json
+   * that is compatible with CRT.
+   *
+   * @param project The Gradle project
+   * @return The zip task
+   */
+  Task createDeploymentZipTask(Project project) {
+    Task zipTask = project.tasks.create(name: "CRTHadoopZip", type: Zip) { task ->
+      archiveName = "${project.name}-${project.version}.zip";
+      classifier = "defaultArtifact";;
+      description = "Creates a Hadoop CRT deployment zip archive";
+      group = "Hadoop Plugin";
+
+      // This task is a dependency of buildHadoopZips and depends on the startHadoopZips
+      project.tasks["buildHadoopZips"].dependsOn task;
+      dependsOn "startHadoopZips";
+
+      // Check that the .crt file exists
+      if (!new File("${project.projectDir}/.crt").exists()) {
+        throw new Exception("Could not find a .crt file at ${project.projectDir}. See go/HadoopCRT for more information.");
+      }
+
+      // The deployment zip consists of just the .crt file
+      from("${project.projectDir}/.crt") {
+        filter(ReplaceTokens, tokens: [version: project.version.toString()]);
+      }
+
+      // Add the task to project artifacts
+      project.artifacts.add("archives", task);
+
+      // When everything is done, print out a message
+      doLast {
+        project.logger.lifecycle("Prepared Hadoop zip archive at: ${archivePath}");
+      }
+    }
+    return zipTask;
   }
 }


### PR DESCRIPTION
Proposed changes as a result of testing the Hadoop zip extension with LinkedIn CRT deployments. This pull request does the following:
- Changes the `cluster` method to `zip`, which I think is more clear for users
- Introduces the `CRT` marker method in the `LiScmPlugin` subclass of the `ScmPlugin` class
- Also introduces the associated `LiHadoopZipExtension` subclass of the `HadoopZipExtension` class

When users use the `CRT` marker method, it produces a zip that is compatible with LinkedIn's one-click deployment system. This zip contains the `.crt` file; is annotated with the `defaultArtifact` classifier; and its archive name is explicitly set to `projectName-projectVersion.zip`, which are workarounds for problems in the LinkedIn deployment system. This is documented in the code as well.
