### PR TITLE
Enable Hadoop Plugin tests to work wth LinkedIn mint snapshot builds

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,10 +17,15 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a version bump, so you will
 see a few skipped version numbers in the list below.
 
+0.6.1
+
+* Enable Hadoop Plugin tests to work wth LinkedIn mint snapshot builds
+* Version bump back to the 0.6.x series
+
 0.5.17
 
-* Fix unit tests for hadoop-plugin module and fix how cross-plugin task dependencies are added
 * LIHADOOP-12945 Hadoop Plugin azkabanUpload enhancement to print project URL
+* Fix unit tests for hadoop-plugin module and fix how cross-plugin task dependencies are added
 * LIHADOOP-12771 Prototype Hadoop Plugin Upload Task for Oozie
 
 0.5.16

--- a/hadoop-plugin-test/build.gradle
+++ b/hadoop-plugin-test/build.gradle
@@ -10,7 +10,7 @@ task forceGradlew(type: Exec) {
 // Create an initial task that sets up the directories for a new test run.
 task initTestCases() {
   dependsOn ":hadoop-plugin:build";
-  dependsOn forceGradlew
+  dependsOn forceGradlew;
   description = "Hadoop DSL task to prepare the test cases";
   group = "Hadoop DSL Tests";
 
@@ -92,13 +92,17 @@ testFiles.each { fileName ->
   String baseDirName = fileName.replace("${baseFileName}.gradle", "").replace("/", "");
   String outputFile = baseDirName.isEmpty() ? "${baseFileName}.out" : "${baseDirName}/${baseFileName}.out";
 
+  // Make the tests work with LinkedIn snapshot builds
+  boolean isSnapshot = project.hasProperty("snapshot") && "true".equals(project.snapshot);
+  String libVersion = isSnapshot ? "${project.version}-SNAPSHOT" : "${project.version}";
+
   project.tasks.create(name: "run_${baseFileName}", type: Exec, dependsOn: initTestCases) {
     description = "Runs Hadoop DSL test case for the file ${fileName} and captures the output";
     group = "Hadoop DSL Tests";
 
     // In LinkedIn internal builds, the dependencies are in a different place, so pass the
     // location on to the test case task.
-    commandLine "${project.projectDir}/../gradlew", "test_${baseFileName}", "-PoverridePluginTestDir=${project.pluginTestDir}"
+    commandLine "${project.projectDir}/../gradlew", "test_${baseFileName}", "-PoverridePluginTestDir=${project.pluginTestDir}", "-PlibVersion=${libVersion}";
     ignoreExitValue true;
 
     // Store the output instead of printing to the console

--- a/hadoop-plugin-test/src/main/gradle/negative/cycles1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/cycles1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/cycles2.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/cycles2.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/invalidNames.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/invalidNames.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/missingFields.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/missingFields.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/propertySetChecks.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/propertySetChecks.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/propertySetCycles.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/propertySetCycles.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/scope1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/scope1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/scope2.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/scope2.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/scope3.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/scope3.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/scope4.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/scope4.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/scope5.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/scope5.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/scope6.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/scope6.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/subflowChecks1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/subflowChecks1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/subflowCycles1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/subflowCycles1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/negative/workflowChecks.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/workflowChecks.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/azkabanZip.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/azkabanZip.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/classes1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/classes1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/cloneLookup.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/cloneLookup.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/cloneSubflows.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/cloneSubflows.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/closures.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/closures.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/definitionSet.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/definitionSet.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/fullyQualifiedLookup.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/fullyQualifiedLookup.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/groovy1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/groovy1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/jobs1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/jobs1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/multiQuery.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/multiQuery.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/names.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/names.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/namespaces.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/namespaces.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/propertyFiles1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/propertyFiles1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/propertySet1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/propertySet1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/readWriteRace1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/readWriteRace1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/readWriteRace2.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/readWriteRace2.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/scope.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/scope.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/subflowReadWriteRace1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/subflowReadWriteRace1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/subflows1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/subflows1.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/triangleDependencies.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/triangleDependencies.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 

--- a/hadoop-plugin-test/src/main/gradle/positive/workflows.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/workflows.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar")
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.libVersion}.jar")
   }
 }
 


### PR DESCRIPTION
Previously when you ran a LinkedIn "mint snapshot" build the hadoop-plugin-test module unit tests failed, because putting -SNAPSHOT in the version number is a LinkedIn-specific construct. This will enable mint snapshot builds to succeed, which helps in local testing at LinkedIn.