### PR TITLE
LIHADOOP-16016: Minor bug fix for li-hadoop-plugin

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,6 +24,7 @@ Vaughan.
 ### Contributors
 
 The following were contributed by Anant Nag. Thanks, Anant!
+* `LIHADOOP-16016 Minor bug fix for li-hadoop-plugin`
 * `LIHADOOP-15728 Update dependency pattern blacklist rules for li-hadoop-plugin`
 * `LIHADOOP-15501 checkDependencies task fails if any of groupID, name or version is null`
 * `LIHADOOP-15077 Hadoop plugin should have a feature to control and monitor dependencies specified by the users`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -19,6 +19,7 @@ see a few skipped version numbers in the list below.
 
 0.7.2
 
+* LIHADOOP-16016 Minor bug fix for li-hadoop-plugin
 * Fix hadoop-plugin subproject unit tests
 * Add generic GatewayCommand helper class for running remote commands through a gateway
 

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/lihadoop/LiHadoopPlugin.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/lihadoop/LiHadoopPlugin.groovy
@@ -129,7 +129,7 @@ class LiHadoopPlugin extends HadoopPlugin {
     Task startHadoopZipsTask = project.tasks.findByName("startHadoopZips");
 
     if (checkDependenciesTask != null && startHadoopZipsTask != null) {    
-      startHadoopZipsTask.dependsOn(checkDependencyTask);
+      startHadoopZipsTask.dependsOn(checkDependenciesTask);
     }
   }
 }


### PR DESCRIPTION
When li-hadoop-plugin is applied to projects, build fails with Error: Failed to apply plugin [class 'com.linkedin.gradle.lihadoop.LiHadoopPlugin']
No such property: checkDependencyTask for class: com.linkedin.gradle.lihadoop.LiHadoopPlugin.

This was introduced in (https://github.com/linkedin/linkedin-gradle-plugin-for-apache-hadoop/pull/31)