### PR TITLE
Fix to restore improper source task name

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,10 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a version bump, so you will
 see a few skipped version numbers in the list below.
 
+0.7.7
+
+* Fix to restore improper source task name
+
 0.7.6
 
 * Fix to restore adding the sources zip and scm metadata files automatically

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.7.6
+version=0.7.7

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liscm/LiScmPlugin.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liscm/LiScmPlugin.groovy
@@ -67,7 +67,7 @@ class LiScmPlugin extends ScmPlugin {
 
         if (buildSrcTask != null) {
           zipTask.dependsOn(buildSrcTask);
-          zipTask.from(sourceTask.archivePath.getAbsolutePath());
+          zipTask.from(buildSrcTask.archivePath.getAbsolutePath());
         }
       }
     }


### PR DESCRIPTION
This should fix the remaining bug from my recent work on the 0.7.x series, allowing me to finish pushing the new version to LinkedIn dependents via go/pmu.