### PR TITLE
LIHADOOP-16591: ligradle azkabanUpload fails with "ClassNotFoundException: org.apache.http.client.methods.HttpPost"

### DIFF
--- a/hadoop-plugin/build.gradle
+++ b/hadoop-plugin/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   compile('org.apache.hadoop:hadoop-common:2.3.0') { transitive = false }
   compile('org.apache.hadoop:hadoop-hdfs:2.3.0')   { transitive = false }
   compile('org.apache.oozie:oozie-client:4.2.0')
+  compile 'org.apache.httpcomponents:httpclient:4.1'
   compile 'org.apache.httpcomponents:httpmime:4.1'
   compile 'org.json:json:20090211'
 


### PR DESCRIPTION
Fix for issue #42.