### PR TITLE
DSS-3870: Hadoop DSL for new Azkaban job type. Teradata <-> HDFS, HDFS -> Espresso, and Gobblin

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,8 @@ the LinkedIn Gradle DSL for Apache Hadoop was influenced by
 Vaughan.
 
 ### Contributors
+The follwing were contributed by Jin Hyuk Chang.
+* `DSS-3870: Hadoop DSL for new Azkaban job type. Teradata <-> HDFS, HDFS -> Espresso, and Gobblin`
 
 The following were contributed by Anthony Hsu. Thanks, Anthony!
 * `LIHADOOP-16591: ligradle azkabanUpload fails with "ClassNotFoundException: org.apache.http.client.methods.HttpPost"`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.7.11
+* DSS-3870 Hadoop DSL for new Azkaban job type. Teradata <-> HDFS, HDFS -> Espresso, and Gobblin
+
 0.7.10
 
 * Fix for LinkedIn PCX builds 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.7.10
+version=0.7.11

--- a/hadoop-plugin-test/expectedJobs/jobs1/jobs1.job
+++ b/hadoop-plugin-test/expectedJobs/jobs1/jobs1.job
@@ -1,3 +1,3 @@
 # This file generated from the Hadoop DSL. Do not edit by hand.
 type=noop
-dependencies=jobs1_job13
+dependencies=jobs1_job17

--- a/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job14.job
+++ b/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job14.job
@@ -1,0 +1,11 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=hdfsToTeradata
+dependencies=jobs1_job13
+avro.schema.path=/data/test/users/user.avsc
+hadoop.config=-Dmapreduce.map.child.java.opts='-Xmx1G -Djava.security.egd=file:/dev/./urandom -Djava.net.preferIPv4Stack=true' -Dmapreduce.job.user.classpath.first=true
+source.hdfs.path=/data/test/users/daily/2015-10-07
+target.td.tablename=dwh_stg.scott_users
+td.credentialName=com.linkedin.teradata.scott
+td.hostname=dw.teradata.com
+td.userid=scott
+user.to.proxy=scott

--- a/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job15.job
+++ b/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job15.job
@@ -1,0 +1,12 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=teradataToHdfs
+dependencies=jobs1_job14
+avro.schema.path=/data/test/users/user.avsc
+force.output.overwrite=true
+hadoop.config=-Dmapreduce.map.child.java.opts='-Xmx1G -Djava.security.egd=file:/dev/./urandom -Djava.net.preferIPv4Stack=true' -Dmapreduce.job.user.classpath.first=true
+source.td.tablename=dwh_stg.scott_users
+target.hdfs.path=/data/test/users/teradata_to_hdfs_test
+td.credentialName=com.linkedin.teradata.scott
+td.hostname=dw.teradata.com
+td.userid=scott
+user.to.proxy=scott

--- a/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job16.job
+++ b/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job16.job
@@ -1,0 +1,14 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=hdfsToEspresso
+dependencies=jobs1_job15
+error.path=/jobs/merlin2/accountMetrics/espressoStaging/error
+espresso.content.type=APPLICATION_JSON
+espresso.database=MerlinAccounts
+espresso.endpoint=http://eat1-app1237.stg.linkedin.com:11936
+espresso.key=accountId
+espresso.operation=put
+espresso.qps=1000
+espresso.subkeys=metricName
+espresso.table=AccountMetric
+force.error.overwrite=true
+input.paths=/jobs/merlin2/accountMetrics/espressoStaging/shortest

--- a/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job17.job
+++ b/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job17.job
@@ -1,0 +1,15 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=gobblin
+dependencies=jobs1_job16
+data.publisher.final.dir=${gobblin.work_dir}/job-output
+data.publisher.replace.final.dir=true
+encrypt.key.loc=/jobs/jnchang/mstr_merlin.key
+extract.is.full=true
+extract.table.type=snapshot_only
+gobblin.config_preset=mysqlToHdfs
+gobblin.work_dir=/jobs/jnchang/azkaban/gobblin
+source.conn.host=eat1-db42.corp.linkedin.com
+source.conn.password=ENC(7Bv+t0aw5rdyOYuyLqkrpTetE3KvfDRK)
+source.conn.username=merlin_u
+source.entity=user
+source.querybased.schema=merlin_users

--- a/hadoop-plugin-test/expectedOutput/negative/missingFields.out
+++ b/hadoop-plugin-test/expectedOutput/negative/missingFields.out
@@ -12,6 +12,27 @@ RequiredFieldsChecker ERROR: PigJob job9 must set script
 RequiredFieldsChecker ERROR: SparkJob job10 must set uses and executes
 RequiredFieldsChecker ERROR: VoldemortBuildPushJob job11 has the following required fields: storeName, clusterName, buildInputPath, buildOutputPath, storeOwners, storeDesc
 RequiredFieldsChecker ERROR: HadoopShellJob job12 must set command or commands
+RequiredFieldsChecker ERROR: HdfsToTeradataJob job13 has the following required fields: hostName
+RequiredFieldsChecker ERROR: HdfsToTeradataJob job13 has the following required fields: userId
+RequiredFieldsChecker ERROR: HdfsToTeradataJob job13 has the following required fields: credentialName
+RequiredFieldsChecker ERROR: HdfsToTeradataJob job13 has the following required fields: sourceHdfsPath
+RequiredFieldsChecker ERROR: HdfsToTeradataJob job13 has the following required fields: targetTable
+RequiredFieldsChecker ERROR: HdfsToTeradataJob job13 needs either avroSchemaPath or avroSchemaInline defined
+RequiredFieldsChecker ERROR: TeradataToHdfsJob job14 has the following required fields: hostName
+RequiredFieldsChecker ERROR: TeradataToHdfsJob job14 has the following required fields: userId
+RequiredFieldsChecker ERROR: TeradataToHdfsJob job14 has the following required fields: credentialName
+RequiredFieldsChecker ERROR: TeradataToHdfsJob job14 has the following required fields: targetHdfsPath
+RequiredFieldsChecker ERROR: TeradataToHdfsJob job14 needs either sourceTable or sourceQuery defined
+RequiredFieldsChecker ERROR: TeradataToHdfsJob job14 needs either avroSchemaPath or avroSchemaInline defined
+RequiredFieldsChecker ERROR: HdfsToEspressoJob job15 has the following error: qps should be a positive number
+RequiredFieldsChecker ERROR: HdfsToEspressoJob job15 has the following required fields: sourceHdfsPath
+RequiredFieldsChecker ERROR: HdfsToEspressoJob job15 has the following required fields: espressoEndpoint
+RequiredFieldsChecker ERROR: HdfsToEspressoJob job15 has the following required fields: espressoDatabaseName
+RequiredFieldsChecker ERROR: HdfsToEspressoJob job15 has the following required fields: espressoTableName
+RequiredFieldsChecker ERROR: HdfsToEspressoJob job15 has the following required fields: espressoContentType
+RequiredFieldsChecker ERROR: HdfsToEspressoJob job15 has the following required fields: espressoKey
+RequiredFieldsChecker ERROR: HdfsToEspressoJob job15 has the following required fields: espressoOperation
+RequiredFieldsChecker ERROR: HdfsToEspressoJob job15 has the following required fields: errorHdfsPath
 RequiredFieldsChecker WARNING: Properties properties1 does not set any confProperties, jobProperties, jvmProperties or basePropertySetName. Nothing will be built for this properties object.
 :hadoop-plugin-test:test_missingFields FAILED
 

--- a/hadoop-plugin-test/src/main/gradle/negative/missingFields.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/missingFields.gradle
@@ -65,6 +65,22 @@ hadoop {
       depends 'job11'
     }
 
-    targets 'job12'
+    hdfsToTeradataJob('job13') {
+      depends 'job12'
+    }
+
+    teradataToHdfsJob('job14') {
+      depends 'job13'
+    }
+
+    hdfsToEspressoJob('job15') {
+      depends 'job14'
+    }
+
+    gobblinJob('job16') {
+      depends 'job15'
+    }
+
+    targets 'job16'
   }
 }

--- a/hadoop-plugin-test/src/main/gradle/positive/jobs1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/jobs1.gradle
@@ -235,6 +235,78 @@ hadoop {
       depends clear: true, targetNames: ['job12']
     }
 
-    targets 'job13'
+    hdfsToTeradataJob('job14') {
+      hostName 'dw.teradata.com'                         //Required
+      userId 'scott'                                     //Required
+      credentialName 'com.linkedin.teradata.scott'       //Required
+      sourceHdfsPath '/data/test/users/daily/2015-10-07' //Required
+      targetTable 'dwh_stg.scott_users'                  //Required
+      avroSchemaPath '/data/test/users/user.avsc'
+      set properties: [                                  //Optional
+        "user.to.proxy": "scott"
+      ]
+
+      set hadoopProperties: [                            //Optional
+        "mapreduce.map.child.java.opts": "'-Xmx1G -Djava.security.egd=file:/dev/./urandom -Djava.net.preferIPv4Stack=true'",
+        "mapreduce.job.user.classpath.first": true
+      ]
+      depends 'job13'
+    }
+
+    teradataToHdfsJob('job15') {
+      hostName 'dw.teradata.com'                         //Required
+      userId 'scott'                                     //Required
+      credentialName 'com.linkedin.teradata.scott'       //Required
+      sourceTable 'dwh_stg.scott_users'                //Required
+      targetHdfsPath '/data/test/users/teradata_to_hdfs_test' //Required
+      avroSchemaPath '/data/test/users/user.avsc'
+      set properties: [                                  //Optional
+        "user.to.proxy": "scott",
+        "force.output.overwrite": true
+      ]
+
+      set hadoopProperties: [                            //Optional
+        "mapreduce.map.child.java.opts": "'-Xmx1G -Djava.security.egd=file:/dev/./urandom -Djava.net.preferIPv4Stack=true'",
+        "mapreduce.job.user.classpath.first": true
+      ]
+      depends 'job14'
+    }
+
+    hdfsToEspressoJob('job16') {
+      qps 1000                                                               //Required
+      sourceHdfsPath '/jobs/merlin2/accountMetrics/espressoStaging/shortest' //Required
+      espressoEndpoint 'http://eat1-app1237.stg.linkedin.com:11936'          //Required
+      espressoDatabaseName 'MerlinAccounts'                                  //Required
+      espressoTableName 'AccountMetric'                                      //Required
+      espressoContentType 'APPLICATION_JSON'                                 //Required
+      espressoKey 'accountId'                                                //Required
+      espressoSubkeys 'metricName'                                           //Optional
+      espressoOperation 'put'                                                //Required
+      errorHdfsPath '/jobs/merlin2/accountMetrics/espressoStaging/error'     //Required
+      set properties: [                                                      //Optional
+        'force.error.overwrite' : true
+      ]
+      depends 'job15'
+    }
+
+    gobblinJob('job17') {
+      workDir '/jobs/jnchang/azkaban/gobblin'  //Optional
+      preset 'mysqlToHdfs'                     //Optional
+      set properties: [                        //Optional
+        'source.querybased.schema' : 'merlin_users',
+        'source.entity' : 'user',
+        'source.conn.host' : 'eat1-db42.corp.linkedin.com',
+        'source.conn.username' : 'merlin_u',
+        'source.conn.password' : 'ENC(7Bv+t0aw5rdyOYuyLqkrpTetE3KvfDRK)',
+        'encrypt.key.loc' : '/jobs/jnchang/mstr_merlin.key',
+        'extract.table.type' : 'snapshot_only',
+        'extract.is.full' : true,
+        'data.publisher.replace.final.dir' : true,
+        'data.publisher.final.dir' :  '${gobblin.work_dir}/job-output'
+      ]
+      depends 'job16'
+    }
+
+    targets 'job17'
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
@@ -16,8 +16,11 @@
 package com.linkedin.gradle.hadoopdsl;
 
 import com.linkedin.gradle.hadoopdsl.job.CommandJob;
+import com.linkedin.gradle.hadoopdsl.job.GobblinJob;
 import com.linkedin.gradle.hadoopdsl.job.HadoopJavaJob;
 import com.linkedin.gradle.hadoopdsl.job.HadoopShellJob;
+import com.linkedin.gradle.hadoopdsl.job.HdfsToEspressoJob;
+import com.linkedin.gradle.hadoopdsl.job.HdfsToTeradataJob;
 import com.linkedin.gradle.hadoopdsl.job.HiveJob;
 import com.linkedin.gradle.hadoopdsl.job.JavaJob;
 import com.linkedin.gradle.hadoopdsl.job.JavaProcessJob;
@@ -26,6 +29,7 @@ import com.linkedin.gradle.hadoopdsl.job.KafkaPushJob;
 import com.linkedin.gradle.hadoopdsl.job.NoOpJob;
 import com.linkedin.gradle.hadoopdsl.job.PigJob;
 import com.linkedin.gradle.hadoopdsl.job.SparkJob;
+import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob;
 import com.linkedin.gradle.hadoopdsl.job.VoldemortBuildPushJob;
 
 import org.gradle.api.Project;
@@ -724,5 +728,54 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
    */
   VoldemortBuildPushJob voldemortBuildPushJob(String name, Closure configure) {
     return configureJob(factory.makeVoldemortBuildPushJob(name), configure);
+  }
+
+  /**
+   * DSL hdfsToTeradataJob method. Creates a HdfsToTeradataJob in scope with the given name
+   * and configuration.
+   *
+   * @param name The job name
+   * @param configure The configuration closure
+   * @return The new job
+   */
+  HdfsToTeradataJob hdfsToTeradataJob(String name, Closure configure) {
+    return configureJob(factory.makeHdfsToTeradataJob(name), configure);
+  }
+
+  /**
+   * DSL teradataToHdfsJob method. Creates a TeradataToHdfsJob in scope with the given name
+   * and configuration.
+   *
+   * @param name The job name
+   * @param configure The configuration closure
+   * @return The new job
+   */
+  TeradataToHdfsJob teradataToHdfsJob(String name, Closure configure) {
+    return configureJob(factory.makeTeradataToHdfsJob(name), configure);
+  }
+
+  /**
+   * DSL hdfsToEspressoJob method. Creates a HdfsToEspressoJob in scope with the given name
+   * and configuration.
+   *
+   * @param name The job name
+   * @param configure The configuration closure
+   * @return The new job
+   */
+  HdfsToEspressoJob hdfsToEspressoJob(String name, Closure configure) {
+    return configureJob(factory.makeHdfsToEspressoJob(name), configure);
+  }
+
+
+  /**
+   * DSL gobblinJob method. Creates a GobblinJob in scope with the given name
+   * and configuration.
+   *
+   * @param name The job name
+   * @param configure The configuration closure
+   * @return The new job
+   */
+  GobblinJob gobblinJob(String name, Closure configure) {
+    return configureJob(factory.makeGobblinJob(name), configure);
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseVisitor.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseVisitor.groovy
@@ -16,8 +16,11 @@
 package com.linkedin.gradle.hadoopdsl;
 
 import com.linkedin.gradle.hadoopdsl.job.CommandJob;
+import com.linkedin.gradle.hadoopdsl.job.GobblinJob;
 import com.linkedin.gradle.hadoopdsl.job.HadoopJavaJob;
 import com.linkedin.gradle.hadoopdsl.job.HadoopShellJob;
+import com.linkedin.gradle.hadoopdsl.job.HdfsToEspressoJob;
+import com.linkedin.gradle.hadoopdsl.job.HdfsToTeradataJob;
 import com.linkedin.gradle.hadoopdsl.job.HiveJob;
 import com.linkedin.gradle.hadoopdsl.job.JavaJob;
 import com.linkedin.gradle.hadoopdsl.job.JavaProcessJob;
@@ -26,6 +29,7 @@ import com.linkedin.gradle.hadoopdsl.job.KafkaPushJob;
 import com.linkedin.gradle.hadoopdsl.job.NoOpJob;
 import com.linkedin.gradle.hadoopdsl.job.PigJob;
 import com.linkedin.gradle.hadoopdsl.job.SparkJob;
+import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob
 import com.linkedin.gradle.hadoopdsl.job.VoldemortBuildPushJob;
 
 /**
@@ -173,6 +177,26 @@ abstract class BaseVisitor implements Visitor {
 
   @Override
   void visitJob(VoldemortBuildPushJob job) {
+    visitJob((Job)job);
+  }
+
+  @Override
+  void visitJob(HdfsToTeradataJob job) {
+    visitJob((Job)job);
+  }
+
+  @Override
+  void visitJob(TeradataToHdfsJob job) {
+    visitJob((Job)job);
+  }
+
+  @Override
+  void visitJob(HdfsToEspressoJob job) {
+    visitJob((Job)job);
+  }
+
+  @Override
+  void visitJob(GobblinJob job) {
     visitJob((Job)job);
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslFactory.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslFactory.groovy
@@ -16,8 +16,11 @@
 package com.linkedin.gradle.hadoopdsl;
 
 import com.linkedin.gradle.hadoopdsl.job.CommandJob;
+import com.linkedin.gradle.hadoopdsl.job.GobblinJob
 import com.linkedin.gradle.hadoopdsl.job.HadoopJavaJob;
 import com.linkedin.gradle.hadoopdsl.job.HadoopShellJob;
+import com.linkedin.gradle.hadoopdsl.job.HdfsToEspressoJob;
+import com.linkedin.gradle.hadoopdsl.job.HdfsToTeradataJob;
 import com.linkedin.gradle.hadoopdsl.job.HiveJob;
 import com.linkedin.gradle.hadoopdsl.job.JavaJob;
 import com.linkedin.gradle.hadoopdsl.job.JavaProcessJob;
@@ -28,6 +31,7 @@ import com.linkedin.gradle.hadoopdsl.job.NoOpJob;
 import com.linkedin.gradle.hadoopdsl.job.PigJob;
 import com.linkedin.gradle.hadoopdsl.job.SparkJob;
 import com.linkedin.gradle.hadoopdsl.job.StartJob
+import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob
 import com.linkedin.gradle.hadoopdsl.job.VoldemortBuildPushJob;
 
 import org.gradle.api.Project;
@@ -198,6 +202,46 @@ class HadoopDslFactory {
    */
   VoldemortBuildPushJob makeVoldemortBuildPushJob(String name) {
     return new VoldemortBuildPushJob(name);
+  }
+
+  /**
+   * Factory method to build a HdfsToTeradataJob
+   *
+   * @param name The job name
+   * @return The job
+   */
+  HdfsToTeradataJob makeHdfsToTeradataJob(String name) {
+    return new HdfsToTeradataJob(name);
+  }
+
+  /**
+   * Factory method to build a TeradataTpHdfsJob
+   *
+   * @param name The job name
+   * @return The job
+   */
+  TeradataToHdfsJob makeTeradataToHdfsJob(String name) {
+    return new TeradataToHdfsJob(name);
+  }
+
+  /**
+   * Factory method to build a HdfsToEspressoJob
+   *
+   * @param name The job name
+   * @return The job
+   */
+  HdfsToEspressoJob makeHdfsToEspressoJob(String name) {
+    return new HdfsToEspressoJob(name);
+  }
+
+  /**
+   * Factory method to build a GobblinJob
+   *
+   * @param name The job name
+   * @return The job
+   */
+  GobblinJob makeGobblinJob(String name) {
+    return new GobblinJob(name);
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
@@ -105,6 +105,10 @@ class HadoopDslPlugin extends BaseNamedScopeContainer implements Plugin<Project>
     project.extensions.add("pigJob", this.&pigJob);
     project.extensions.add("sparkJob", this.&sparkJob);
     project.extensions.add("voldemortBuildPushJob", this.&voldemortBuildPushJob);
+    project.extensions.add("hdfsToTeradataJob", this.&hdfsToTeradataJob);
+    project.extensions.add("teradataToHdfsJob", this.&teradataToHdfsJob);
+    project.extensions.add("hdfsToEspressoJob", this.&hdfsToEspressoJob);
+    project.extensions.add("gobblinJob", this.&gobblinJob);
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/NamedScopeContainer.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/NamedScopeContainer.groovy
@@ -16,8 +16,11 @@
 package com.linkedin.gradle.hadoopdsl;
 
 import com.linkedin.gradle.hadoopdsl.job.CommandJob;
+import com.linkedin.gradle.hadoopdsl.job.GobblinJob
 import com.linkedin.gradle.hadoopdsl.job.HadoopJavaJob;
 import com.linkedin.gradle.hadoopdsl.job.HadoopShellJob;
+import com.linkedin.gradle.hadoopdsl.job.HdfsToEspressoJob
+import com.linkedin.gradle.hadoopdsl.job.HdfsToTeradataJob;
 import com.linkedin.gradle.hadoopdsl.job.HiveJob;
 import com.linkedin.gradle.hadoopdsl.job.JavaJob;
 import com.linkedin.gradle.hadoopdsl.job.JavaProcessJob;
@@ -26,6 +29,7 @@ import com.linkedin.gradle.hadoopdsl.job.KafkaPushJob;
 import com.linkedin.gradle.hadoopdsl.job.NoOpJob;
 import com.linkedin.gradle.hadoopdsl.job.PigJob;
 import com.linkedin.gradle.hadoopdsl.job.SparkJob;
+import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob
 import com.linkedin.gradle.hadoopdsl.job.VoldemortBuildPushJob;
 
 /**
@@ -267,4 +271,44 @@ interface NamedScopeContainer {
    * @return The new job
    */
   VoldemortBuildPushJob voldemortBuildPushJob(String name, Closure configure);
+
+  /**
+   * DSL hdfsToTeradataJob method. Creates a HdfsToTeradataJob in scope with the given name
+   * and configuration.
+   *
+   * @param name The job name
+   * @param configure The configuration closure
+   * @return The new job
+   */
+  HdfsToTeradataJob hdfsToTeradataJob(String name, Closure configure);
+
+  /**
+   * DSL teradataToHdfsJob method. Creates a TeradataToHdfsJob in scope with the given name
+   * and configuration.
+   *
+   * @param name The job name
+   * @param configure The configuration closure
+   * @return The new job
+   */
+  TeradataToHdfsJob teradataToHdfsJob(String name, Closure configure);
+
+  /**
+   * DSL hdfsToEspresso method. Creates a HdfsToEspressoJob in scope with the given name
+   * and configuration.
+   *
+   * @param name The job name
+   * @param configure The configuration closure
+   * @return The new job
+   */
+  HdfsToEspressoJob hdfsToEspressoJob(String name, Closure configure);
+
+  /**
+   * DSL gobblinJob method. Creates a GobblinJob in scope with the given name
+   * and configuration.
+   *
+   * @param name The job name
+   * @param configure The configuration closure
+   * @return The new job
+   */
+  GobblinJob gobblinJob(String name, Closure configure);
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Visitor.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Visitor.groovy
@@ -16,8 +16,11 @@
 package com.linkedin.gradle.hadoopdsl;
 
 import com.linkedin.gradle.hadoopdsl.job.CommandJob;
+import com.linkedin.gradle.hadoopdsl.job.GobblinJob;
 import com.linkedin.gradle.hadoopdsl.job.HadoopJavaJob;
 import com.linkedin.gradle.hadoopdsl.job.HadoopShellJob;
+import com.linkedin.gradle.hadoopdsl.job.HdfsToEspressoJob;
+import com.linkedin.gradle.hadoopdsl.job.HdfsToTeradataJob;
 import com.linkedin.gradle.hadoopdsl.job.HiveJob;
 import com.linkedin.gradle.hadoopdsl.job.JavaJob;
 import com.linkedin.gradle.hadoopdsl.job.JavaProcessJob;
@@ -26,6 +29,7 @@ import com.linkedin.gradle.hadoopdsl.job.KafkaPushJob;
 import com.linkedin.gradle.hadoopdsl.job.NoOpJob;
 import com.linkedin.gradle.hadoopdsl.job.PigJob;
 import com.linkedin.gradle.hadoopdsl.job.SparkJob;
+import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob;
 import com.linkedin.gradle.hadoopdsl.job.VoldemortBuildPushJob;
 
 /**
@@ -54,4 +58,8 @@ interface Visitor {
   void visitJob(PigJob job);
   void visitJob(SparkJob job);
   void visitJob(VoldemortBuildPushJob job);
+  void visitJob(HdfsToTeradataJob job);
+  void visitJob(TeradataToHdfsJob job);
+  void visitJob(HdfsToEspressoJob job);
+  void visitJob(GobblinJob job);
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/GobblinJob.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/GobblinJob.groovy
@@ -1,0 +1,73 @@
+package com.linkedin.gradle.hadoopdsl.job;
+
+import com.linkedin.gradle.hadoopdsl.NamedScope;
+
+/**
+ * Job class for type=gobblinJob jobs.
+ *
+ * <p>
+ * According to the Azkaban documentation at http://azkaban.github.io/azkaban/docs/latest/#job-types,
+ * this is the job type that lauches Gobblin in Azkaban
+ * <p>
+ * In the DSL, a GobblinJob can be specified with:
+ * <pre>
+ *   gobblinJob('jobName') {
+ *     workDir '/job/data/src'  //Optional
+ *     preset 'mysqlToHdfs'     //Optional
+ *     set properties: [        //Optional Add Gobblin job properties. (https://github.com/linkedin/gobblin/wiki/Working-with-Job-Configuration-Files)
+ *       'source.querybased.schema' : 'merlin_users',
+ *       'source.entity' : 'user',
+ *       'source.conn.host' : 'eat1-db42.corp.linkedin.com',
+ *       'source.conn.username' : 'merlin_u',
+ *       'source.conn.password' : 'ENC(7Bv+t0aw5rdyOYuyLqkrpTetE3KvfDRK)',
+ *       'encrypt.key.loc' : '/jobs/jnchang/mstr_merlin.key',
+ *       'extract.table.type' : 'snapshot_only',
+ *       'extract.is.full' : true,
+ *       'data.publisher.replace.final.dir' : true,
+ *       'data.publisher.final.dir' :  '${gobblin.work_dir}/job-output',
+ *       'gobblinJobPropertyKey1' : 'gobblinJobPropertyValue1',
+ *       'gobblinJobPropertyKey2' : 'gobblinJobPropertyValue2',
+ *     ]
+ *   }
+ * </pre>
+ */
+class GobblinJob extends Job {
+  String workDir;
+  String preset;
+
+  public GobblinJob(String jobName) {
+    super(jobName);
+    setJobProperty("type", "gobblin");
+  }
+
+  void workDir(String workDir) {
+    this.workDir = workDir;
+    setJobProperty("gobblin.work_dir", workDir);
+  }
+
+  void preset(String preset) {
+    this.preset = preset;
+    setJobProperty("gobblin.config_preset", preset);
+  }
+
+  /**
+   * Clones the job.
+   *
+   * @return The cloned job
+   */
+  @Override
+  GobblinJob clone() {
+    return clone(new GobblinJob(name));
+  }
+
+  /**
+   * Helper method to set the properties on a cloned job.
+   * @param cloneJob The job being cloned
+   * @return The cloned job
+   */
+  GobblinJob clone(GobblinJob cloneJob) {
+    cloneJob.workDir = workDir;
+    cloneJob.preset = preset;
+    return super.clone(cloneJob);
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/HdfsToEspressoJob.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/HdfsToEspressoJob.groovy
@@ -1,0 +1,128 @@
+package com.linkedin.gradle.hadoopdsl.job;
+
+import com.linkedin.gradle.hadoopdsl.NamedScope;
+
+/**
+ * Job class for type=hdfsToEspressoJob jobs.
+ *
+ * <p>
+ * These are documented internally at LinkedIn at https://iwww.corp.linkedin.com/wiki/cf/pages/viewpage.action?pageId=145670487
+ * This is the job type to move data from HDFS to Espresso
+ * <p>
+ * In the DSL, a HdfsToEspressoJob can be specified with:
+ * <pre>
+ *   hdfsToEspressoJob('jobName') {
+ *     qps 1000                        //Required
+ *     sourceHdfsPath '/job/data/src'  //Required
+ *     espressoEndpoint 'www.foo.bar'  //Required
+ *     espressoDatabaseName 'Account'  //Required
+ *     espressoTableName 'Person'      //Required
+ *     espressoContentType 'JSON/TEXT' //Required
+ *     espressoKey 'id'                //Required
+ *     espressoSubkeys 'sub_id,name'   //Optional
+ *     espressoOperation 'put'         //Required
+ *     errorHdfsPath '/job/data/err'   //Required
+ *     set properties: [
+ *       'force.error.overwrite' : true,
+ *       'propertyName1' : 'propertyValue1',
+ *       'propertyName2' : 'propertyValue2',
+ *     ]
+ *   }
+ * </pre>
+ */
+class HdfsToEspressoJob extends Job {
+  int qps;
+  String sourceHdfsPath;
+  String espressoEndpoint;
+  String espressoDatabaseName;
+  String espressoTableName;
+  String espressoContentType;
+  String espressoKey;
+  String espressoSubkeys;
+  String espressoOperation;
+  String errorHdfsPath;
+
+  public HdfsToEspressoJob(String jobName) {
+    super(jobName);
+    setJobProperty("type", "hdfsToEspresso");
+  }
+
+  void qps(int qps) {
+    this.qps = qps;
+    setJobProperty("espresso.qps", qps);
+  }
+
+  void sourceHdfsPath(String sourceHdfsPath) {
+    this.sourceHdfsPath = sourceHdfsPath;
+    setJobProperty("input.paths", sourceHdfsPath);
+  }
+
+  void espressoEndpoint(String espressoEndpoint) {
+    this.espressoEndpoint = espressoEndpoint;
+    setJobProperty("espresso.endpoint", espressoEndpoint);
+  }
+
+  void espressoDatabaseName(String espressoDatabaseName) {
+    this.espressoDatabaseName = espressoDatabaseName;
+    setJobProperty("espresso.database", espressoDatabaseName);
+  }
+
+  void espressoTableName(String espressoTableName) {
+    this.espressoTableName = espressoTableName;
+    setJobProperty("espresso.table", espressoTableName);
+  }
+
+  void espressoContentType(String espressoContentType) {
+    this.espressoContentType = espressoContentType;
+    setJobProperty("espresso.content.type", espressoContentType);
+  }
+
+  void espressoKey(String espressoKey) {
+    this.espressoKey = espressoKey;
+    setJobProperty("espresso.key", espressoKey);
+  }
+
+  void espressoSubkeys(String espressoSubkeys) {
+    this.espressoSubkeys = espressoSubkeys;
+    setJobProperty("espresso.subkeys", espressoSubkeys);
+  }
+
+  void espressoOperation(String espressoOperation) {
+    this.espressoOperation = espressoOperation;
+    setJobProperty("espresso.operation", espressoOperation);
+  }
+
+  void errorHdfsPath(String errorHdfsPath) {
+    this.errorHdfsPath = errorHdfsPath;
+    setJobProperty("error.path", errorHdfsPath);
+  }
+
+  /**
+   * Clones the job.
+   *
+   * @return The cloned job
+   */
+  @Override
+  HdfsToEspressoJob clone() {
+    return clone(new HdfsToEspressoJob(name));
+  }
+
+  /**
+   * Helper method to set the properties on a cloned job.
+   * @param cloneJob The job being cloned
+   * @return The cloned job
+   */
+  HdfsToEspressoJob clone(HdfsToEspressoJob cloneJob) {
+    cloneJob.qps = qps;
+    cloneJob.sourceHdfsPath = sourceHdfsPath;
+    cloneJob.espressoEndpoint = espressoEndpoint;
+    cloneJob.espressoDatabaseName = espressoDatabaseName;
+    cloneJob.espressoTableName = espressoTableName;
+    cloneJob.espressoContentType = espressoContentType;
+    cloneJob.espressoKey = espressoKey;
+    cloneJob.espressoSubkeys = espressoSubkeys;
+    cloneJob.espressoOperation = espressoOperation;
+    cloneJob.errorHdfsPath = errorHdfsPath;
+    return super.clone(cloneJob);
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/HdfsToTeradataJob.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/HdfsToTeradataJob.groovy
@@ -1,0 +1,133 @@
+package com.linkedin.gradle.hadoopdsl.job;
+
+import com.linkedin.gradle.hadoopdsl.NamedScope;
+
+/**
+ * Job class for type=hdfsToTeradataJob jobs.
+ * <p>
+ * According to the Azkaban documentation at http://azkaban.github.io/azkaban/docs/latest/#job-types,
+ * this is the job type to move data from HDFS to Teradata
+ * <p>
+ * In the DSL, a HdfsToTeradataJob can be specified with:
+ * <pre>
+ *   hdfsToTeradataJob('jobName') {
+ *     hostName 'dw.foo.com'  // Required
+ *     userId 'scott' //Required
+ *     credentialName 'com.linkedin.teradata.scott' //Required
+ *     sourceHdfsPath '/job/data/src' //Required
+ *     targetTable 'teradatatable' //Required
+ *     avroSchemaPath '/job/data/src/avro.avsc'
+ *     avroSchemaInline '{"type":"record","namespace":"com.example","name":"FullName","fields":[{"name":"first","type":"string"},{"name":"last","type":"string"}]}'
+ *     set hadoopProperties: [
+ *       'hadoopPropertyName1' : 'hadoopPropertyValue1',
+ *       'hadoopPropertyName2' : 'hadoopPropertyValue2'
+ *     ]
+ *   }
+ * </pre>
+ */
+class HdfsToTeradataJob extends Job {
+  String hostName;
+  String userId;
+  String credentialName;
+  String sourceHdfsPath;
+  String targetTable;
+  String avroSchemaPath;
+  String avroSchemaInline;
+  final Map<String, Object> hadoopProperties;
+
+  public HdfsToTeradataJob(String jobName) {
+    super(jobName);
+    setJobProperty("type", "hdfsToTeradata");
+    hadoopProperties = new LinkedHashMap<String, Object>();
+  }
+
+  @Override
+  Map<String, String> buildProperties(NamedScope parentScope) {
+    Map<String, String> allProperties = super.buildProperties(parentScope);
+
+    if (hadoopProperties.size() > 0) {
+      String hadoopConfig = hadoopProperties.collect() { String key, Object val -> return "-D${key}=${val.toString()}" }.join(" ");
+      allProperties["hadoop.config"] = hadoopConfig;
+    }
+
+    return allProperties;
+  }
+
+  void hostName(String hostName) {
+    this.hostName = hostName;
+    setJobProperty("td.hostname", hostName);
+  }
+
+  void userId(String userId) {
+    this.userId = userId;
+    setJobProperty("td.userid", userId);
+  }
+
+  void credentialName(String credentialName) {
+    this.credentialName = credentialName;
+    setJobProperty("td.credentialName", credentialName);
+  }
+
+  void sourceHdfsPath(String sourceHdfsPath) {
+    this.sourceHdfsPath = sourceHdfsPath;
+    setJobProperty("source.hdfs.path", sourceHdfsPath);
+  }
+
+  void targetTable(String targetTable) {
+    this.targetTable = targetTable;
+    setJobProperty("target.td.tablename", targetTable);
+  }
+
+  void avroSchemaPath(String avroSchemaPath) {
+    this.avroSchemaPath = avroSchemaPath;
+    setJobProperty("avro.schema.path", avroSchemaPath);
+  }
+
+  void avroSchemaInline(String avroSchemaInline) {
+    this.avroSchemaInline = avroSchemaInline;
+    setJobProperty("avro.schema.inline", avroSchemaInline);
+  }
+
+  void setHadoopProperty(String name, Object value) {
+    hadoopProperties.put(name, value);
+  }
+
+  @Override
+  void set(Map args) {
+    super.set(args);
+
+    if (args.containsKey("hadoopProperties")) {
+      Map<String, Object> hadoopProperties = args.hadoopProperties;
+      hadoopProperties.each() { name, value ->
+        setHadoopProperty(name, value);
+      }
+    }
+  }
+
+  /**
+   * Clones the job.
+   *
+   * @return The cloned job
+   */
+  @Override
+  HdfsToTeradataJob clone() {
+    return clone(new HdfsToTeradataJob(name));
+  }
+
+  /**
+   * Helper method to set the properties on a cloned job.
+   * @param cloneJob The job being cloned
+   * @return The cloned job
+   */
+  HdfsToTeradataJob clone(HdfsToTeradataJob cloneJob) {
+    cloneJob.hostName = hostName;
+    cloneJob.userId = userId;
+    cloneJob.credentialName = credentialName;
+    cloneJob.sourceHdfsPath = sourceHdfsPath;
+    cloneJob.targetTable = targetTable;
+    cloneJob.avroSchemaPath = avroSchemaPath;
+    cloneJob.avroSchemaInline = avroSchemaInline;
+    cloneJob.hadoopProperties = new LinkedHashMap<String, String>(hadoopProperties);
+    return super.clone(cloneJob);
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/TeradataToHdfsJob.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/TeradataToHdfsJob.groovy
@@ -1,0 +1,141 @@
+package com.linkedin.gradle.hadoopdsl.job;
+
+import com.linkedin.gradle.hadoopdsl.NamedScope;
+
+/**
+ * Job class for type=teradataToHdfsJob jobs.
+ * <p>
+ * According to the Azkaban documentation at http://azkaban.github.io/azkaban/docs/latest/#job-types,
+ * this is the job type to move data from HDFS to Teradata
+ * <p>
+ * In the DSL, a TeradataToHdfsJob can be specified with:
+ * <pre>
+ *   teradataToHdfsJob('jobName') {
+ *     hostName 'dw.foo.com'  // Required
+ *     userId 'scott' //Required
+ *     credentialName 'com.linkedin.teradata.scott' //Required
+ *     sourceTable 'person' //Either sourceTable or sourceQuery is required
+ *     sourceQuery 'select * from person;' //Either sourceTable or sourceQuery is required
+ *     targetHdfsPath '/job/data/test/output' //Required
+ *     avroSchemaPath '/job/data/src/avro.avsc'
+ *     avroSchemaInline '{"type":"record","namespace":"com.example","name":"FullName","fields":[{"name":"first","type":"string"},{"name":"last","type":"string"}]}'
+ *     set hadoopProperties: [
+ *       'hadoopPropertyName1' : 'hadoopPropertyValue1',
+ *       'hadoopPropertyName2' : 'hadoopPropertyValue2'
+ *     ]
+ *   }
+ * </pre>
+ */
+class TeradataToHdfsJob extends Job {
+  String hostName;
+  String userId;
+  String credentialName;
+  String sourceTable;
+  String sourceQuery;
+  String targetHdfsPath;
+  String avroSchemaPath;
+  String avroSchemaInline;
+  final Map<String, Object> hadoopProperties;
+
+  public TeradataToHdfsJob(String jobName) {
+    super(jobName);
+    setJobProperty("type", "teradataToHdfs");
+    hadoopProperties = new LinkedHashMap<String, Object>();
+  }
+
+  @Override
+  Map<String, String> buildProperties(NamedScope parentScope) {
+    Map<String, String> allProperties = super.buildProperties(parentScope);
+
+    if (hadoopProperties.size() > 0) {
+      String hadoopConfig = hadoopProperties.collect() { String key, Object val -> return "-D${key}=${val.toString()}" }.join(" ");
+      allProperties["hadoop.config"] = hadoopConfig;
+    }
+
+    return allProperties;
+  }
+
+  void hostName(String hostName) {
+    this.hostName = hostName;
+    setJobProperty("td.hostname", hostName);
+  }
+
+  void userId(String userId) {
+    this.userId = userId;
+    setJobProperty("td.userid", userId);
+  }
+
+  void credentialName(String credentialName) {
+    this.credentialName = credentialName;
+    setJobProperty("td.credentialName", credentialName);
+  }
+
+  void sourceTable(String sourceTable) {
+    this.sourceTable = sourceTable;
+    setJobProperty("source.td.tablename", sourceTable);
+  }
+
+  void sourceQuery(String sourceQuery) {
+    this.sourceQuery = sourceQuery;
+    setJobProperty("source.td.sourcequery", sourceQuery);
+  }
+
+  void targetHdfsPath(String targetHdfsPath) {
+    this.targetHdfsPath = targetHdfsPath;
+    setJobProperty("target.hdfs.path", targetHdfsPath);
+  }
+
+  void avroSchemaPath(String avroSchemaPath) {
+    this.avroSchemaPath = avroSchemaPath;
+    setJobProperty("avro.schema.path", avroSchemaPath);
+  }
+
+  void avroSchemaInline(String avroSchemaInline) {
+    this.avroSchemaInline = avroSchemaInline;
+    setJobProperty("avro.schema.inline", avroSchemaInline);
+  }
+
+  void setHadoopProperty(String name, Object value) {
+    hadoopProperties.put(name, value);
+  }
+
+  @Override
+  void set(Map args) {
+    super.set(args);
+
+    if (args.containsKey("hadoopProperties")) {
+      Map<String, Object> hadoopProperties = args.hadoopProperties;
+      hadoopProperties.each() { name, value ->
+        setHadoopProperty(name, value);
+      }
+    }
+  }
+
+  /**
+   * Clones the job.
+   *
+   * @return The cloned job
+   */
+  @Override
+  TeradataToHdfsJob clone() {
+    return clone(new TeradataToHdfsJob(name));
+  }
+
+  /**
+   * Helper method to set the properties on a cloned job.
+   * @param cloneJob The job being cloned
+   * @return The cloned job
+   */
+  TeradataToHdfsJob clone(TeradataToHdfsJob cloneJob) {
+    cloneJob.hostName = hostName;
+    cloneJob.userId = userId;
+    cloneJob.credentialName = credentialName;
+    cloneJob.sourceTable = sourceTable;
+    cloneJob.sourceQuery = sourceQuery;
+    cloneJob.targetHdfsPath = targetHdfsPath;
+    cloneJob.avroSchemaPath = avroSchemaPath;
+    cloneJob.avroSchemaInline = avroSchemaInline;
+    cloneJob.hadoopProperties = new LinkedHashMap<String, String>(hadoopProperties);
+    return super.clone(cloneJob);
+  }
+}


### PR DESCRIPTION
DSS-3870: Hadoop DSL for new Azkaban job type. Teradata <-> HDFS, HDFS -> Espresso, and Gobblin

Unit tested.
Integration tested by creating job files and by executing in Azkaban.

Teradata <-> HDFS: https://iwww.corp.linkedin.com/wiki/cf/pages/viewpage.action?pageId=144296934
HDFS -> Espresso: https://iwww.corp.linkedin.com/wiki/cf/pages/viewpage.action?pageId=145670487
Gobblin: https://iwww.corp.linkedin.com/wiki/cf/pages/viewpage.action?pageId=148020872