### PR TITLE
LIHADOOP-22222 Display Upload Status of Zip while running azkabanUpload task

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -80,3 +80,4 @@ The following were contributed by Ragesh Rajagopalan. Thanks, Ragesh!
 The following were contributed by Pranay Hasan Yerra. Thanks, Pranay!
 * 'LIHADOOP-21797 Automate the creation of the .azkabanPlugin.json file'
 * 'LIHADOOP-21658 Refactor AzkabanUploadTask in Hadoop Plugin by creating AzkabanHelper class'
+* 'LIHADOOP-22222 Display Upload Status of Zip while running azkabanUpload task'

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,10 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.9.16
+
+* LIHADOOP-22222 Display Upload Status of Zip when running azkabanUpload task
+
 0.9.15
 
 * Added Hive ORC table as a source in hdfsToTeradata job type

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.9.15
+version=0.9.16

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
@@ -107,6 +107,10 @@ class AzkabanPlugin implements Plugin<Project> {
           interactive = false;
         }
 
+        if (project.hasProperty("showProgress")) {
+          AzkabanUploadTask.showProgress = true;
+        }
+
         azkProject = readAzkabanProject(project);
         String zipTaskName = azkProject.azkabanZipTask;
         if (!zipTaskName) {
@@ -128,6 +132,10 @@ class AzkabanPlugin implements Plugin<Project> {
       doLast {
         if (interactive) {
           logger.lifecycle("\nUse -PskipInteractive command line parameter to skip asking for confirmation and ONLY read from the .azkabanPlugin.json file.");
+        }
+
+        if (!AzkabanUploadTask.showProgress) {
+          logger.lifecycle("Use -PshowProgress command line parameter to show the Zip Upload status.");
         }
       }
     }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/ProgressHttpEntityWrapper.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/ProgressHttpEntityWrapper.groovy
@@ -1,0 +1,57 @@
+package com.linkedin.gradle.azkaban;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.HttpEntityWrapper;
+
+
+public class ProgressHttpEntityWrapper extends HttpEntityWrapper {
+
+  private final ProgressCallback _progressCallback;
+
+  public static interface ProgressCallback {
+    public void progress(float progress);
+  }
+
+  public ProgressHttpEntityWrapper(final HttpEntity entity, final ProgressCallback progressCallback) {
+    super(entity);
+    this._progressCallback = progressCallback;
+  }
+
+  @Override
+  public void writeTo(final OutputStream out) throws IOException {
+    this.wrappedEntity.writeTo(out instanceof ProgressFilterOutputStream ? out : new ProgressFilterOutputStream(out, this._progressCallback, getContentLength()));
+  }
+
+  static class ProgressFilterOutputStream extends FilterOutputStream {
+
+    private final ProgressCallback _progressCallback;
+    private long _transferred;
+    private long _totalBytes;
+
+    ProgressFilterOutputStream(final OutputStream out, final ProgressCallback progressCallback, final long totalBytes) {
+      super(out);
+      this._progressCallback = progressCallback;
+      this._transferred = 0;
+      this._totalBytes = totalBytes;
+    }
+
+    @Override
+    public void write(final byte[] b, final int off, final int len) throws IOException {
+      out.write(b, off, len);
+      this._transferred += len;
+      this._progressCallback.progress(getCurrentProgress());
+    }
+
+    @Override
+    public void write(final int b) throws IOException {
+      out.write(b);
+      this._transferred++;
+      this._progressCallback.progress(getCurrentProgress());
+    }
+
+    private float getCurrentProgress() {
+      return ((float) this._transferred / this._totalBytes) * 100;
+    }
+  }
+
+}


### PR DESCRIPTION
Updates the progress of Zip that has been uploaded when azkabanUpload task is used. Useful when uploading huge Zips.