### PR TITLE
Display custom message after azkabanUpload task

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -80,6 +80,7 @@ The following were contributed by Ragesh Rajagopalan. Thanks, Ragesh!
 * `DI-584 Login prompt missing when uploading to Azkaban`
 
 The following were contributed by Pranay Hasan Yerra. Thanks, Pranay!
+* `LIHADOOP-23788 Display custom message after azkabanUpload task`
 * `LIHADOOP-22850 Handle null console and minor changes in upload bar's display`
 * `LIHADOOP-22822 The azkabanUpload task should automatically go into edit mode if there are missing required fields`
 * `LIHADOOP-22809 Display configured Hadoop zips during azkabanUpload task`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,10 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.10.13
+
+* Display custom message after azkabanUpload task.
+
 0.10.12
 
 * Enable properly redeclaring the paths your Hadoop DSL job reads and writes

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.10.12
+version=0.10.13

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
@@ -38,7 +38,7 @@ import static com.linkedin.gradle.azkaban.AzkabanConstants.*;
 class AzkabanPlugin implements Plugin<Project> {
 
   boolean interactive = true;
-  private final static Logger logger = Logging.getLogger(AzkabanPlugin);
+  protected final Logger logger = Logging.getLogger(AzkabanPlugin);
 
   /**
    * Applies the AzkabanPlugin. This adds the Gradle task that builds the Hadoop DSL for Azkaban.
@@ -129,6 +129,7 @@ class AzkabanPlugin implements Plugin<Project> {
       doLast {
         if (interactive) {
           logger.lifecycle("\nUse -PskipInteractive command line parameter to skip interactive mode and ONLY read from the .azkabanPlugin.json file.");
+          printUploadMessage();
         }
       }
     }
@@ -197,6 +198,12 @@ class AzkabanPlugin implements Plugin<Project> {
    */
   AzkabanProject makeDefaultAzkabanProject(Project project) {
     return makeAzkabanProject();
+  }
+
+  /**
+   * Prints a message after upload to Azkaban is done. Subclasses can override this method.
+   */
+  void printUploadMessage() {
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanUploadTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanUploadTask.groovy
@@ -104,7 +104,7 @@ class AzkabanUploadTask extends DefaultTask {
     return new ProgressHttpEntityWrapper.ProgressCallback() {
       @Override
       public void progress(float progress) {
-        if((int)progress > progressLimiter && progressLimiter <= 100) {
+        if(((int)progress) > progressLimiter && progressLimiter <= 100) {
           progressLimiter++;
           print("x");
           System.out.flush();
@@ -195,7 +195,7 @@ class AzkabanUploadTask extends DefaultTask {
       logger.lifecycle("\n--------------------------------------------------------------------------------");
       logger.lifecycle(AzkabanHelper.parseResponse(response.toString()));
       String result = AzkabanHelper.parseContent(response.getEntity().getContent());
-      logger.lifecycle("\n" + result);
+      logger.lifecycle(result);
       logger.lifecycle("--------------------------------------------------------------------------------");
 
       // Check if there was an error during the upload.

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanPlugin.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanPlugin.groovy
@@ -15,16 +15,19 @@
  */
 package com.linkedin.gradle.liazkaban;
 
-
 import com.linkedin.gradle.azkaban.AzkabanDslCompiler;
 import com.linkedin.gradle.azkaban.AzkabanPlugin;
 import com.linkedin.gradle.azkaban.AzkabanProject;
+
 import org.gradle.api.Project;
 
 /**
  * LinkedIn-specific customizations to the Azkaban Plugin.
  */
 class LiAzkabanPlugin extends AzkabanPlugin {
+
+  private static final String MESSAGE_URL = "https://gitli.corp.linkedin.com/hadoop-dev/azkaban-linkedin-files/raw/li-hadoop-plugin_message.txt";
+
   /**
    * Factory method to build a default AzkabanProject for use with the writePluginJson method. Can
    * be overridden by subclasses.
@@ -55,5 +58,21 @@ class LiAzkabanPlugin extends AzkabanPlugin {
   @Override
   AzkabanDslCompiler makeCompiler(Project project) {
     return new LiAzkabanDslCompiler(project);
+  }
+
+  /**
+   * Prints Linkedin specific message after upload to Azkaban completes, mostly to notify Azkaban users of
+   * upcoming changes. Subclasses can override this method.
+   */
+  @Override
+  void printUploadMessage() {
+    try {
+      String message = MESSAGE_URL.toURL().getText();
+      if (!message.isEmpty() && message.length() > 0) {
+        logger.lifecycle("\n"+message);
+      }
+    } catch (Exception ex) {
+      logger.error("Failed to fetch message. Error: " + ex.getMessage());
+    }
   }
 }


### PR DESCRIPTION
This can be useful to notify users on recent developments after azkabanUpload task completes, especially specific to Linkedin. As the file with the message is maintained in an internal repository, the messages are visible only to company users, and no code changes are needed to make changes to the message. Additionally, empty file displays no message to users.