### PR TITLE
LIHADOOP-24729 Fix azkabanExecuteFlow console output and jline dependency override from azkaban-client

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,11 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.11.2
+
+* LIHADOOP-24729 Addressed improper console output for azkabanExecuteFlow task
+* Fix jline dependency override in hadoop-plugin from azkaban-client subproject
+
 0.11.1
 
 * LIHADOOP-24274 Checks for empty fields in .azkabanplugin.json

--- a/azkaban-client/build.gradle
+++ b/azkaban-client/build.gradle
@@ -15,10 +15,6 @@ dependencies {
   compile 'org.apache.httpcomponents:httpmime:4.5.2'
   compile 'org.json:json:20090211'
   compile 'joda-time:joda-time:2.9.4'
-  compile 'jline:jline:2.12.1'
-
-  runtime 'com.sun.jersey:jersey-client:1.19.1'
-  runtime 'com.sun.jersey:jersey-core:1.19.1'
 
   testCompile group: 'junit', name: 'junit', version: '4.11'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.11.1
+version=0.11.2

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanExecuteFlowTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanExecuteFlowTask.groovy
@@ -105,10 +105,11 @@ class AzkabanExecuteFlowTask extends DefaultTask {
    * @return indexSet Set of entered indices corresponding to flows
    */
   static Set<String> getFlowIndicesInput() {
-    String input = AzkabanHelper.consoleInput(System.console(), " > Enter indices of flows to be executed > ", false);
+    def console = System.console();
+    String input = AzkabanHelper.consoleInput(console, " > Enter indices of flows to be executed > ", true);
     Set<String> indexSet = new HashSet<String>(Arrays.asList(input.split("\\D+")));
-    while(indexSet.isEmpty()) {
-      input = AzkabanHelper.consoleInput(System.console(), " > Enter correct indices of flows to be executed > ", false);
+    while(!input.trim().length() || indexSet.isEmpty()) {
+      input = AzkabanHelper.consoleInput(console, "> Enter correct indices of flows to be executed > ", true);
       indexSet = new HashSet<String>(Arrays.asList(input.split("\\D+")));
     }
     return indexSet;
@@ -120,10 +121,7 @@ class AzkabanExecuteFlowTask extends DefaultTask {
    * @param flows List of flows in the Azkaban Project.
    */
   void printFlowsWithIndices(List<String> flows) {
-    logger.lifecycle("-----    -----");
-    logger.lifecycle("INDEX    FLOWS");
-    logger.lifecycle("-----    -----");
-
+    logger.lifecycle("-----    -----\nINDEX    FLOWS\n-----    -----");
     flows.eachWithIndex { String flow, index ->
       logger.lifecycle(" ${index}       ${flow}");
     }


### PR DESCRIPTION
**FIX**

1. Execute Flow task's console output conflicts with build message.
2. Remove _jline:2.12.1_ dependency in azkaban-client sub-project which overrides existing old _jline:1.0_ dependency causing Hadoop Validator to throw the below error.
```
Execution failed for task ':hello-pig-azkaban:pigSyntaxValidate'.
> jline/ConsoleReaderInputStream
```