### PR TITLE
Add possibility to group jobs into subflows in Azkaban UI

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -98,3 +98,6 @@ The following were contributed by Pratik Satish. Thanks, Pratik!
 
 The following were contributed by Ivan Heda. Thanks, Ivan!
 * `Added possibility to have Azkaban password in configuration JSON.`
+
+The following were contributed by Alexander Ivaniuk:
+* Add possibility to group jobs into subflows in Azkaban UI

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,10 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.11.13
+
+* Improvement of visual presentation of generated flows in Azkaban - Add ability to group job nodes in a subflow 
+
 0.11.12
 
 * Expand on the list of file types automatically excluded from the sources zip to exclude archive types

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.11.12
+version=0.11.13

--- a/hadoop-plugin-test/expectedJobs/groupingFlow/groupingFlow.job
+++ b/hadoop-plugin-test/expectedJobs/groupingFlow/groupingFlow.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=flow
+flow.name=groupingFlow_groupingFlow

--- a/hadoop-plugin-test/expectedJobs/groupingFlow/groupingFlow_groupingFlow.job
+++ b/hadoop-plugin-test/expectedJobs/groupingFlow/groupingFlow_groupingFlow.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop
+dependencies=groupingFlow_job1,groupingFlow_groupingSubFlow

--- a/hadoop-plugin-test/expectedJobs/groupingFlow/groupingFlow_job1.job
+++ b/hadoop-plugin-test/expectedJobs/groupingFlow/groupingFlow_job1.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop
+dependencies=groupingFlow_job2

--- a/hadoop-plugin-test/expectedJobs/groupingFlow/groupingFlow_job2.job
+++ b/hadoop-plugin-test/expectedJobs/groupingFlow/groupingFlow_job2.job
@@ -1,0 +1,2 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop

--- a/hadoop-plugin-test/expectedJobs/groupingFlow/groupingSubFlow/groupingFlow_groupingSubFlow.job
+++ b/hadoop-plugin-test/expectedJobs/groupingFlow/groupingSubFlow/groupingFlow_groupingSubFlow.job
@@ -1,0 +1,4 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=flow
+dependencies=groupingFlow_job1
+flow.name=groupingFlow_groupingSubFlow_groupingSubFlow

--- a/hadoop-plugin-test/expectedJobs/groupingFlow/groupingSubFlow/groupingFlow_groupingSubFlow__start.job
+++ b/hadoop-plugin-test/expectedJobs/groupingFlow/groupingSubFlow/groupingFlow_groupingSubFlow__start.job
@@ -1,0 +1,2 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop

--- a/hadoop-plugin-test/expectedJobs/groupingFlow/groupingSubFlow/groupingFlow_groupingSubFlow_groupingSubFlow.job
+++ b/hadoop-plugin-test/expectedJobs/groupingFlow/groupingSubFlow/groupingFlow_groupingSubFlow_groupingSubFlow.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop
+dependencies=groupingFlow_groupingSubFlow_sub-job1

--- a/hadoop-plugin-test/expectedJobs/groupingFlow/groupingSubFlow/groupingFlow_groupingSubFlow_sub-job1.job
+++ b/hadoop-plugin-test/expectedJobs/groupingFlow/groupingSubFlow/groupingFlow_groupingSubFlow_sub-job1.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop
+dependencies=groupingFlow_groupingSubFlow__start

--- a/hadoop-plugin-test/expectedJobs/nonGroupingFlow/groupingSubFlow2/nonGroupingFlow_groupingSubFlow2.job
+++ b/hadoop-plugin-test/expectedJobs/nonGroupingFlow/groupingSubFlow2/nonGroupingFlow_groupingSubFlow2.job
@@ -1,0 +1,4 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=flow
+dependencies=nonGroupingFlow_job1
+flow.name=nonGroupingFlow_groupingSubFlow2_groupingSubFlow2

--- a/hadoop-plugin-test/expectedJobs/nonGroupingFlow/groupingSubFlow2/nonGroupingFlow_groupingSubFlow2__start.job
+++ b/hadoop-plugin-test/expectedJobs/nonGroupingFlow/groupingSubFlow2/nonGroupingFlow_groupingSubFlow2__start.job
@@ -1,0 +1,2 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop

--- a/hadoop-plugin-test/expectedJobs/nonGroupingFlow/groupingSubFlow2/nonGroupingFlow_groupingSubFlow2_groupingSubFlow2.job
+++ b/hadoop-plugin-test/expectedJobs/nonGroupingFlow/groupingSubFlow2/nonGroupingFlow_groupingSubFlow2_groupingSubFlow2.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop
+dependencies=nonGroupingFlow_groupingSubFlow2_sub-job1

--- a/hadoop-plugin-test/expectedJobs/nonGroupingFlow/groupingSubFlow2/nonGroupingFlow_groupingSubFlow2_sub-job1.job
+++ b/hadoop-plugin-test/expectedJobs/nonGroupingFlow/groupingSubFlow2/nonGroupingFlow_groupingSubFlow2_sub-job1.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop
+dependencies=nonGroupingFlow_groupingSubFlow2__start

--- a/hadoop-plugin-test/expectedJobs/nonGroupingFlow/nonGroupingFlow.job
+++ b/hadoop-plugin-test/expectedJobs/nonGroupingFlow/nonGroupingFlow.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop
+dependencies=nonGroupingFlow_job1,nonGroupingFlow_groupingSubFlow2

--- a/hadoop-plugin-test/expectedJobs/nonGroupingFlow/nonGroupingFlow_job1.job
+++ b/hadoop-plugin-test/expectedJobs/nonGroupingFlow/nonGroupingFlow_job1.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop
+dependencies=nonGroupingFlow_job2

--- a/hadoop-plugin-test/expectedJobs/nonGroupingFlow/nonGroupingFlow_job2.job
+++ b/hadoop-plugin-test/expectedJobs/nonGroupingFlow/nonGroupingFlow_job2.job
@@ -1,0 +1,2 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop

--- a/hadoop-plugin-test/expectedOutput/positive/groupingWorkflows.out
+++ b/hadoop-plugin-test/expectedOutput/positive/groupingWorkflows.out
@@ -1,0 +1,10 @@
+:hadoop-plugin-test:test_groupingWorkflows
+Running test for the file positive/groupingWorkflows.gradle
+RequiredFieldsChecker WARNING: NoOpJob job2 does not declare any dependencies. It won't do anything.
+RequiredFieldsChecker WARNING: NoOpJob sub-job1 does not declare any dependencies. It won't do anything.
+RequiredFieldsChecker WARNING: NoOpJob job2 does not declare any dependencies. It won't do anything.
+RequiredFieldsChecker WARNING: NoOpJob sub-job1 does not declare any dependencies. It won't do anything.
+Hadoop DSL static checker PASSED
+
+BUILD SUCCESSFUL
+

--- a/hadoop-plugin-test/src/main/gradle/positive/groupingWorkflows.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/groupingWorkflows.gradle
@@ -1,0 +1,59 @@
+buildscript {
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// test grouping subflow jobs
+hadoop {
+  buildPath "jobs"
+  cleanPath false
+
+  workflow('groupingFlow') {
+    // job1 is not defined yet
+
+    groupJobs true
+
+    targets 'job1', 'groupingSubFlow'
+
+    noOpJob('job1') {
+      depends 'job2'
+    }
+
+    workflow('groupingSubFlow') {
+      groupJobs true
+
+      noOpJob('sub-job1') {
+      }
+
+      flowDepends 'job1'
+      targets 'sub-job1'
+    }
+
+    noOpJob('job2') {
+    }
+  }
+
+  workflow('nonGroupingFlow') {
+    targets 'job1', 'groupingSubFlow2'
+
+    noOpJob('job1') {
+      depends 'job2'
+    }
+
+    workflow('groupingSubFlow2') {
+      groupJobs true
+
+      noOpJob('sub-job1') {
+      }
+
+      flowDepends 'job1'
+      targets 'sub-job1'
+    }
+
+    noOpJob('job2') {
+    }
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslFactory.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslFactory.groovy
@@ -15,7 +15,7 @@
  */
 package com.linkedin.gradle.hadoopdsl;
 
-import com.linkedin.gradle.hadoopdsl.job.CommandJob;
+import com.linkedin.gradle.hadoopdsl.job.CommandJob
 import com.linkedin.gradle.hadoopdsl.job.GobblinJob
 import com.linkedin.gradle.hadoopdsl.job.HadoopJavaJob;
 import com.linkedin.gradle.hadoopdsl.job.HadoopShellJob;
@@ -32,6 +32,7 @@ import com.linkedin.gradle.hadoopdsl.job.PigJob;
 import com.linkedin.gradle.hadoopdsl.job.SparkJob;
 import com.linkedin.gradle.hadoopdsl.job.SqlJob
 import com.linkedin.gradle.hadoopdsl.job.StartJob
+import com.linkedin.gradle.hadoopdsl.job.SubFlowJob
 import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob
 import com.linkedin.gradle.hadoopdsl.job.VoldemortBuildPushJob;
 
@@ -144,6 +145,16 @@ class HadoopDslFactory {
    */
   KafkaPushJob makeKafkaPushJob(String name) {
     return new KafkaPushJob(name);
+  }
+
+  /**
+   * Factory method to build a SubFlowJob.
+   *
+   * @param name The job name
+   * @return The job
+   */
+  SubFlowJob makeSubFlowJob(String name) {
+    return new SubFlowJob(name);
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/SubFlowJob.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/SubFlowJob.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.gradle.hadoopdsl.job;
+
+import com.linkedin.gradle.hadoopdsl.NamedScope;
+
+
+/**
+ * SubFlowJob is a job that groups all its children jobs into a parent node in Azkaban.
+ */
+class SubFlowJob extends StartJob {
+  /**
+   * Root of a jobs' graph that defines the group
+   */
+  String targetJobName;
+
+  /**
+   * Constructor for a SubFlowJob.
+   *
+   * @param jobName The job name
+   */
+  SubFlowJob(String jobName) {
+    super(jobName);
+    setJobProperty("type", "flow");
+  }
+
+  /**
+   * Method to construct the file name to use for the job file. In Azkaban, all job files must have
+   * unique names.
+   * <p>
+   * For a SubFlowJob, the file name is simply the cleaned fully-qualified workflow name.
+   *
+   * @param parentScope The parent scope in which the job is bound
+   * @return The name to use when generating the job file
+   */
+  @Override
+  String buildFileName(NamedScope parentScope) {
+    // The file name for a launch job is just the cleaned up fully-qualified workflow name.
+    return cleanFileName(parentScope.getQualifiedName());
+  }
+
+  void targets(String jobName) {
+    targetJobName = jobName;
+  }
+
+  /**
+   * Builds the job properties that go into the generated job file, except for the dependencies
+   * property, which is built by the other overload of the buildProperties method.
+   * <p>
+   * Subclasses can override this method to add their own properties, and are recommended to
+   * additionally call this base class method to add the jobProperties correctly.
+   *
+   * @param parentScope The parent scope in which to lookup the base properties
+   * @return The job properties map that holds all the properties that will go into the built job file
+   */
+  @Override
+  Map<String, String> buildProperties(NamedScope parentScope) {
+    Map<String, String> allProperties = super.buildProperties(parentScope);
+    // flow.name defines a root of jobs' dependency graph that will be used to group them
+    allProperties['flow.name'] = buildFileName(parentScope, targetJobName);
+
+    return allProperties;
+  }
+
+  /**
+   * Clones the job.
+   *
+   * @return The cloned job
+   */
+  @Override
+  SubFlowJob clone() {
+    return clone(new SubFlowJob(name));
+  }
+
+  /**
+   * Helper method to set the properties on a cloned job.
+   *
+   * @param cloneJob The job being cloned
+   * @return The cloned job
+   */
+  SubFlowJob clone(SubFlowJob cloneJob) {
+    return ((SubFlowJob)super.clone(cloneJob));
+  }
+
+}


### PR DESCRIPTION
Currently, Hadoop DSL doesn't support embedded flows (see http://azkaban.github.io/azkaban/docs/latest/#creating-flows).

This change allows to specify "groupJobs true" in the workflow DSL to convert it into an embedded Azkaban flow automatically.
