### PR TITLE
Added possibility to have Azkaban password in configuration JSON.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -93,3 +93,6 @@ The following were contributed by Pranay Hasan Yerra. Thanks, Pranay!
 
 The following were contributed by Pratik Satish. Thanks, Pratik!
 * `LIHADOOP-21429 Add HadoopValidatorPlugin with PigValidatorPlugin in its stack`
+
+The following were contributed by Ivan Heda. Thanks, Ivan!
+* `Added possibility to have Azkaban password in configuration JSON.`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.11.7
+* Added possibility to have Azkaban password in configuration JSON.
+
 0.11.6
 
 * Hadoop DSL IDE Syntax Completion for IntelliJ - Add annotation to help expose top-level Hadoop DSL methods

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.11.6
+version=0.11.7

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanConstants.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanConstants.groovy
@@ -21,4 +21,5 @@ final class AzkabanConstants {
   static final String AZK_USER_NAME = "azkabanUserName";
   static final String AZK_VAL_AUTO_FIX = "azkabanValidatorAutoFix";
   static final String AZK_ZIP_TASK = "azkabanZipTask";
+  static final String AZK_PASSWORD = "azkabanPassword";
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
@@ -372,6 +372,7 @@ class AzkabanPlugin implements Plugin<Project> {
       azkProject.azkabanUserName = pluginJson[AZK_USER_NAME];
       azkProject.azkabanValidatorAutoFix = pluginJson[AZK_VAL_AUTO_FIX];
       azkProject.azkabanZipTask = pluginJson[AZK_ZIP_TASK];
+      azkProject.azkabanPassword = pluginJson[AZK_PASSWORD];
     } else {
       // If the file doesn't exist, the task should automatically ask the user for this information
       logger.lifecycle("File .azkabanPlugin.json not found. Automatically switching to interactive mode.");

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanProject.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanProject.groovy
@@ -21,4 +21,5 @@ class AzkabanProject {
   String azkabanUserName = "";
   String azkabanValidatorAutoFix = "";
   String azkabanZipTask = "";
+  String azkabanPassword = null;
 }


### PR DESCRIPTION
There are several cases when it is beneficial to have password stored directly in configuration JSON, so the plugin doesn't need to open system console. Among these situations are for example building via IDE plugin or Jenkins build. In both examples is no system console available. 