### PR TITLE
LIHADOOP-26059 Change in azkabanUpload task error message and azkaban CancelFlow task console output

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,10 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.11.10
+
+* LIHADOOP-26059 Change in azkabanUpload task error message and azkabanCancelFlow task console output.
+
 0.11.9
 
 * LIHADOOP-25566 Update Dr.Elephant URL link in azkabanFlowStatus task

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.11.9
+version=0.11.10

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCancelFlowTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCancelFlowTask.groovy
@@ -101,7 +101,7 @@ class AzkabanCancelFlowTask extends DefaultTask {
           printStatus(flows, responseList);
 
           //Get exec ID's to kill
-          String input =  AzkabanHelper.consoleInput(System.console(), " > Enter IDs of executions to be killed:", false);
+          String input =  AzkabanHelper.consoleInput(System.console(), " > Enter IDs of executions to be killed:", true);
           if(input.isEmpty()) {
             logger.error("Entered Nothing, Exiting...");
             return;

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanHelper.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanHelper.groovy
@@ -123,7 +123,7 @@ class AzkabanHelper {
   static boolean configureTask(AzkabanProject azkProject, Project project) {
     def console = System.console();
     if (console == null) {
-      String msg = "\nCannot access the system console. To use this task, explicitly set JAVA_HOME to the version specified in product-spec.json (at LinkedIn) and pass --no-daemon in your command.";
+      String msg = "\nCannot access the system console. Refer to https://github.com/linkedin/linkedin-gradle-plugin-for-apache-hadoop/wiki/Azkaban-Features#password-masking";
       throw new GradleException(msg);
     }
 


### PR DESCRIPTION
1.  Updated the pointer to wiki page when azkabanUpload fails to give a comprehensive guide of what the issue might be. 

2. Corrected CancelFlow task to display the entry of message which is being overridden by build