### PR TITLE
Rename conflicting Azkaban test extension and task names to not collide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,3 @@
 bin
 build
 ligradle
-oozie-jaxb/schema
-oozie-jaxb/src/main/java

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -20,6 +20,7 @@ version bump, so you will see a few skipped version numbers in the list below.
 0.11.17
 
 * Remove unfinished Oozie Hadoop DSL elements to simplify the long-term maintenance overhead
+* Rename conflicting Azkaban test extension and task names to not collide
 
 0.11.16
 

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslExtension.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslExtension.groovy
@@ -121,8 +121,8 @@ class HadoopDslExtension extends BaseNamedScopeContainer {
    * @return The Test object
    */
   @HadoopDslMethod
-  TestExtension test(String name, @DelegatesTo(TestExtension) Closure configure) {
-    return configureTest(factory.makeTest(name, project, scope), configure);
+  TestExtension hadoopTest(String name, @DelegatesTo(TestExtension) Closure configure) {
+    return configureHadoopTest(factory.makeTest(name, project, scope), configure);
   }
 
   /**
@@ -133,7 +133,7 @@ class HadoopDslExtension extends BaseNamedScopeContainer {
    * @param configure The configuration closure
    * @return The input test, which is now configured
    */
-  protected TestExtension configureTest(TestExtension test, Closure configure) {
+  protected TestExtension configureHadoopTest(TestExtension test, Closure configure) {
     scope.bind(test.name, test);
     project.configure(test, configure);
     this.tests.add(test);

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
@@ -97,7 +97,6 @@ class HadoopDslPlugin extends BaseNamedScopeContainer implements Plugin<Project>
     project.extensions.add("propertyFile", this.&propertyFile);
     project.extensions.add("propertySet", this.&propertySet);
     project.extensions.add("workflow", this.&workflow);
-    project.extensions.add("test", this.&test);
     project.extensions.add("commandJob", this.&commandJob);
     project.extensions.add("gobblinJob", this.&gobblinJob);
     project.extensions.add("hadoopJavaJob", this.&hadoopJavaJob);


### PR DESCRIPTION
This is an emergency PR to rename tasks and extension methods that collide with names elsewhere. For example, the "test" extension method collides with the "test" configuration provided by the Gradle Java plugin.

@nntnag17 Although I am going to commit this immediately to unblock our PCX build at LinkedIn, can you take a look at this and re-rename anything I already renamed to names that you like? I just chose the first name that came to mind. Additionally, please check my changes and see if I broke other parts of your code.