### PR TITLE
Add supports for a `required parameters` check

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -107,3 +107,6 @@ The following were contributed by Alexander Ivaniuk. Thanks, Alexander!
 The following were contributed by Jennifer Dai. Thanks, Jennifer!
 * `Add ability for Hadoop DSL to understand the PinotBuildAndPushJob job type`
 
+The following were contributed by Jianling Zhong. Thanks, Jianling!
+* `Add supports for a "required parameters" check`
+

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,10 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.11.18
+
+* Add supports for a `required parameters` check
+
 0.11.17
 
 * Remove unfinished Oozie Hadoop DSL elements to simplify the long-term maintenance overhead

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.11.17
+version=0.11.18

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslChecker.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslChecker.groovy
@@ -17,7 +17,8 @@ package com.linkedin.gradle.hadoopdsl;
 
 import com.linkedin.gradle.hadoopdsl.checker.JobDependencyChecker;
 import com.linkedin.gradle.hadoopdsl.checker.PropertySetChecker;
-import com.linkedin.gradle.hadoopdsl.checker.RequiredFieldsChecker
+import com.linkedin.gradle.hadoopdsl.checker.RequiredFieldsChecker;
+import com.linkedin.gradle.hadoopdsl.checker.RequiredParametersChecker;
 import com.linkedin.gradle.hadoopdsl.checker.ValidFieldsChecker;
 import com.linkedin.gradle.hadoopdsl.checker.ValidNameChecker;
 import com.linkedin.gradle.hadoopdsl.checker.WorkflowJobChecker;
@@ -58,6 +59,7 @@ class HadoopDslChecker extends BaseStaticChecker {
     List<StaticChecker> checks = new ArrayList<StaticChecker>();
     checks.add(makeValidNameChecker());
     checks.add(makeRequiredFieldsChecker());
+    checks.add(makeRequiredParametersChecker());
     checks.add(makeWorkflowJobChecker());
     checks.add(makeJobDependencyChecker());
     checks.add(makePropertySetChecker());
@@ -109,6 +111,16 @@ class HadoopDslChecker extends BaseStaticChecker {
    */
   RequiredFieldsChecker makeRequiredFieldsChecker() {
     return new RequiredFieldsChecker(project);
+  }
+
+  /**
+   * Factory method to build the RequiredParametersChecker check. Allows subclasses to provide a custom
+   * implementation of this check.
+   *
+   * @return The RequiredParametersChecker check
+   */
+  RequiredParametersChecker makeRequiredParametersChecker() {
+    return new RequiredParametersChecker(project);
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/RequiredParametersChecker.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/RequiredParametersChecker.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.gradle.hadoopdsl.checker
+
+import com.linkedin.gradle.hadoopdsl.job.Job
+import com.linkedin.gradle.hadoopdsl.BaseStaticChecker
+import com.linkedin.gradle.hadoopdsl.Workflow
+
+import org.gradle.api.Project
+
+class RequiredParametersChecker extends BaseStaticChecker {
+  /**
+   * Constructor for the requiredParametersChecker.
+   *
+   * @param project The Gradle project
+   */
+  RequiredParametersChecker(Project project) {
+    super(project);
+  }
+
+  void checkRequiredParameters(Job job, List<String> flowPath) {
+    if (!job.requiredParameters.isEmpty()) {
+      job.requiredParameters.each { para ->
+        if (!job.jobProperties.containsKey(para)) {
+          String jobPath = flowPath.join('/') + '/' + job.name;
+          project.logger.lifecycle("RequiredParametersChecker ERROR: Job ${jobPath} requires parameter ${para}, but it is not set.");
+          foundError = true;
+        }
+      }
+    }
+  }
+
+  @Override
+  void visitWorkflow(Workflow workflow) {
+    List<String> flowPath = [workflow.name];
+    visitWorkflow(workflow, flowPath);
+  }
+
+  void visitWorkflow(Workflow workflow, List<String> flowPath) {
+    workflow.workflows.each { Workflow flow ->
+      flowPath.push(flow.name);
+      visitWorkflow(flow, flowPath);
+    }
+
+    workflow.jobs.each { Job job ->
+      checkRequiredParameters(job, flowPath);
+    }
+
+    flowPath.pop();
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/Job.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/Job.groovy
@@ -48,6 +48,7 @@ class Job {
   Map<String, Object> jobProperties;
   Map<String, String> reading;
   Map<String, String> writing;
+  Set<String> requiredParameters;
 
   /**
    * Base constructor for a Job.
@@ -60,6 +61,7 @@ class Job {
     name = jobName;
     reading = new LinkedHashMap<String, String>();
     writing = new LinkedHashMap<String, String>();
+    requiredParameters = new LinkedHashSet<String>();
   }
 
   /**
@@ -202,6 +204,7 @@ class Job {
     cloneJob.jobProperties.putAll(jobProperties);
     cloneJob.reading.putAll(reading);
     cloneJob.writing.putAll(writing);
+    cloneJob.requiredParameters.addAll(requiredParameters);
     return cloneJob;
   }
 
@@ -329,6 +332,23 @@ class Job {
     }
   }
 
+  /**
+   * DSL method to specify required parameters for a job.
+   * Certain parameters must be set explicitly in oder for the job to run correctly in production.
+   * Specifying those parameters here provides a clear and explicit expectation for the users of the job.
+   * For example, specifying "required parameters" in a job template,
+   * and then enforcing the setting of those parameters in a job cloned from this template.
+   * This helps avoid production errors in an early stage, such as those caused by default parameters.
+   *
+   * @param args Args whose key 'parameters' has a list of value specifying the required parameters
+   */
+  @HadoopDslMethod
+  void required(Map args) {
+    List<String> parameters = args.parameters;
+    for (String entry : parameters) {
+      requiredParameters.add(entry);
+    }
+  }
   /**
    * Sets the given job property. Setting a job property causes a line of the form key=val to be
    * written to the job file.


### PR DESCRIPTION
Jobs can now use a "required parameters: []" section to specify any parameters that are required to be set in order for the job to run correctly in production. A static checker is also added so that if any of the required parameters is not set, the DSL static checker will fail.