### PR TITLE
Removed automatic include of runtime dependencies into libPath in ZipTask

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -99,6 +99,7 @@ The following were contributed by Pratik Satish. Thanks, Pratik!
 * `LIHADOOP-21429 Add HadoopValidatorPlugin with PigValidatorPlugin in its stack`
 
 The following were contributed by Ivan Heda. Thanks, Ivan!
+* `Removed automatic include of runtime dependencies into libPath in ZipTask.`
 * `Added possibility to have Azkaban password in configuration JSON.`
 
 The following were contributed by Alexander Ivaniuk. Thanks, Alexander!

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/zip/HadoopZipExtension.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/zip/HadoopZipExtension.groovy
@@ -13,14 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.linkedin.gradle.zip;
+package com.linkedin.gradle.zip
 
-import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.file.CopySpec;
-import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.tasks.bundling.Zip;
-
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.CopySpec
+import org.gradle.api.tasks.bundling.Zip
 /**
  * A hadoopZip makes it convenient for the user to make specific choices about how their content
  * goes inside the zip. In the hadoopZip, the user can specify files and folders which should go
@@ -160,14 +158,6 @@ class HadoopZipExtension {
       else {
         task.with(getZipCopySpec(zipName));
       }
-
-      // For Java projects, include the project jar into the libPath directory in the zip by default
-      project.getPlugins().withType(JavaPlugin) {
-        from(project.tasks.getByName("jar")) { into libPath; }
-      }
-
-      // Include hadoopRuntime dependencies into the libPath directory in the zip
-      from(project.configurations["hadoopRuntime"]) { into libPath; }
 
       // Include any additional paths added to the extension
       additionalPaths.each { String path -> from(path); }

--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/zip/HadoopZipTest.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/zip/HadoopZipTest.groovy
@@ -105,13 +105,18 @@ class HadoopZipTest {
   }
 
   /**
-   * Basic test that just adds jars from the hadoopRuntime configuration.
+   * Basic test that just manually adds jars from the hadoopRuntime configuration.
    */
   @Test
   void testHadoopConfiguration() {
     plugin.apply(project);
 
     hadoopRuntime.getDependencies().add(project.getDependencies().create(project.fileTree("AzRoot/custom-lib")));
+
+    project.extensions.hadoopZip.base({
+      from(hadoopRuntime) { into "lib"; }
+    })
+
     project.extensions.hadoopZip.main({});
 
     Set<String> expected = new HashSet<String>();


### PR DESCRIPTION
Hey, 

I believe it's not necessary to include automatically all runtime dependencies as these could be provided from different place or in fat jar. Automatic including could in such situations result into massive uploading even when it's not necessary. On the other hand it's straightforward to add these dependencies manually when needed.

