### PR TITLE
Minor fix to the test plugin

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,6 +40,7 @@ The following were contributed by Jonathan Hung. Thanks, Jonathan!
 * `TOOLS-67569 Block Hadoop Client Teams from checking in Hadoop Jars in their MP`
 
 The following were contributed by Anant Nag. Thanks, Anant!
+* `Minor fix to the test plugin`
 * `LIHADOOP-28747 Hadoop plugin's test plugin should have functionality to add assertions on tests.`
 * `LIHADOOP-25519 ligradle tasks to test the flow on Azkaban`
 * `LIHADOOP-25518 Prototype deploy tests for the workflows`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,10 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.12.6
+
+* Minor fix to the test plugin
+
 0.12.5
 
 * Add Hadoop DSL applyUserProfile method

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.12.5
+version=0.12.6

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoop/HadoopPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoop/HadoopPlugin.groovy
@@ -276,6 +276,7 @@ class HadoopPlugin implements Plugin<Project> {
     setupPigPluginTaskDependencies(project);
     setupScmPluginTaskDependencies(project);
     setupSparkPluginTaskDependencies(project);
+    setupTestPluginTaskDependencies(project);
   }
 
   /**
@@ -425,6 +426,20 @@ class HadoopPlugin implements Plugin<Project> {
 
     if (localDependencyTask != null && hadoopZips != null) {
       hadoopZips.dependsOn localDependencyTask;
+    }
+  }
+
+  /**
+   * Helper method to setup the dependencies between the buildFlowsForTesting task and the buildSourceZip
+   * task in the root project. Subclasses can override this method to customize their own task dependencies
+   * @param project
+   */
+  void setupTestPluginTaskDependencies(Project project) {
+    Task buildFlowsForTestingTask = project.tasks.findByName("buildFlowsForTesting");
+    Task buildSourceZipTask = project.getRootProject().tasks.findByName("buildSourceZip");
+
+    if(buildFlowsForTestingTask!=null && buildSourceZipTask!=null) {
+      buildFlowsForTestingTask.mustRunAfter buildSourceZipTask
     }
   }
 }


### PR DESCRIPTION
If the task buildFlowsForTesting on the subproject and buildSourceZip on the root project run at the same time, buildSourceZip is not able to find some files since they are deleted by buildFlowsForTesting. This PR fixes the issue. 