### PR TITLE
Minor fixes to the Azkaban CLI tasks

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,10 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.12.4
+
+* Minor fixes to the Azkaban CLI tasks
+
 0.12.3
 
 * Minor documentation and style fixes

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.12.3
+version=0.12.4

--- a/hadoop-plugin/build.gradle
+++ b/hadoop-plugin/build.gradle
@@ -46,6 +46,7 @@ dependencies {
   runtime 'com.sun.jersey:jersey-core:1.9'
   runtime 'javax.ws.rs:jsr311-api:1.1.1'
   runtime 'jline:jline:1.0'
+  runtime 'joda-time:joda-time:2.9.4'
   runtime 'org.mortbay.jetty:jetty-util:6.1.25'
 }
 

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanBlockedFlowStatusTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanBlockedFlowStatusTask.groovy
@@ -13,16 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.linkedin.gradle.azkaban;
-
 
 import com.linkedin.gradle.azkaban.client.AzkabanClient;
 import com.linkedin.gradle.util.IOUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
 import org.json.JSONObject;
-
 
 /**
  * This class provides the functionality to fetch the status of the flows when they are completed.
@@ -32,7 +29,8 @@ class AzkabanBlockedFlowStatusTask extends AzkabanFlowStatusTask {
   private static final Long POLLING_WAIT_TIME = 20000; // default 20s
 
   /**
-   * The Gradle task action for getting flowStatus from Azkaban.*/
+   * The Gradle task action for getting flowStatus from Azkaban.
+   **/
   @TaskAction
   void status() {
     if (azkProject.azkabanUrl == null) {
@@ -42,7 +40,8 @@ class AzkabanBlockedFlowStatusTask extends AzkabanFlowStatusTask {
   }
 
   /**
-   * This function returns the list of flows from which status should be fetched
+   * This function returns the list of flows from which status should be fetched.
+   *
    * @return The list of flows from which status should be fetched
    */
   List<String> getFlowsToFetchStatus() {
@@ -62,13 +61,13 @@ class AzkabanBlockedFlowStatusTask extends AzkabanFlowStatusTask {
     }
   }
 
-/**
- * This method waits for the flow to finish. It polls
- * the Azkabban server and outputs the flows that finished immediately.
- * At the end of the function, it outputs the summary of all the flows that
- * have finished
- * @param sessionId The session id for the Azkaban session
- */
+  /**
+   * This method waits for the flow to finish. It polls the Azkaban server and outputs the flows
+   * that finished immediately. At the end of the function, it outputs the summary of all the flows
+   * that have finished.
+   *
+   * @param sessionId The session ID for the Azkaban session
+   */
   void getBlockedAzkabanFlowStatus(String sessionId) {
     // list of all the flows defined in the project
     List<String> flows = getSortedFlows(sessionId);
@@ -99,8 +98,8 @@ class AzkabanBlockedFlowStatusTask extends AzkabanFlowStatusTask {
 
     Set<String> flowsYetToFinish = new HashSet<String>();
     flowsYetToFinish.addAll(flowsToFetchStatusFrom); // initially all flows are yet to finish
-
     int countOfFlowsFinished = 0;
+
     while (!flowsYetToFinish.empty && !execIds.isEmpty()) {
 
       if (!execIds.isEmpty()) {
@@ -157,7 +156,8 @@ class AzkabanBlockedFlowStatusTask extends AzkabanFlowStatusTask {
   }
 
   /**
-   * This method filters out the flows that have finished and returns them
+   * This method filters out the flows that have finished and returns them.
+   *
    * @param responseList The reponseList from Azkaban
    * @return The list of flows that have completed
    */
@@ -166,7 +166,7 @@ class AzkabanBlockedFlowStatusTask extends AzkabanFlowStatusTask {
     for (int j = 0; j < responseList.size(); j++) {
       String jobResponse = responseList.get(j);
       JSONObject jobsObject = new JSONObject(jobResponse);
-      if (!jobsObject.get("status").equals("RUNNING") && !jobsObject.equals("READY")) {
+      if (!jobsObject.get("status").equals("RUNNING") && !jobsObject.get("status").equals("READY")) {
         filteredJobResponse.add(jobResponse);
       }
     }
@@ -174,7 +174,8 @@ class AzkabanBlockedFlowStatusTask extends AzkabanFlowStatusTask {
   }
 
   /**
-   * Given a list of Azkaban reponse json, extract the flow names and return it as a list
+   * Given a list of Azkaban response json, extract the flow names and return it as a list.
+   *
    * @param responseList The responseList from Azkaban
    * @return The list of names of the workflows defined in responseList
    */
@@ -183,9 +184,8 @@ class AzkabanBlockedFlowStatusTask extends AzkabanFlowStatusTask {
     for (int j = 0; j < responseList.size(); j++) {
       String jobResponse = responseList.get(j);
       JSONObject jobsObject = new JSONObject(jobResponse);
-      filteredJobResponse.add(jobsObject.get("flow"));
+      filteredJobResponse.add(jobsObject.get("flow").toString());
     }
     return filteredJobResponse;
   }
-
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCancelFlowTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCancelFlowTask.groovy
@@ -46,133 +46,127 @@ class AzkabanCancelFlowTask extends DefaultTask {
   /**
    * Cancels running flows in Azkaban.
    *
-   * @param sessionId The Azkaban session id. If this is null, an attempt will be made to login to Azkaban.
+   * @param sessionId The Azkaban session ID. If this is null, an attempt will be made to login to Azkaban.
    */
   void cancelRunningAzkabanFlow(String sessionId) {
-
+    // Fetch the project flows
     sessionId = AzkabanHelper.resumeOrGetSession(sessionId, azkProject);
+    String fetchFlowsResponse = AzkabanClient.fetchProjectFlows(azkProject.azkabanUrl, azkProject.azkabanProjName, sessionId);
 
-    try {
-      //Fetch flows of the project
-      String fetchFlowsResponse = AzkabanClient.fetchProjectFlows(azkProject.azkabanUrl, azkProject.azkabanProjName, sessionId);
-
-      if (fetchFlowsResponse.toLowerCase().contains("error")) {
-        // Check if session has expired. If so, re-login.
-        if (fetchFlowsResponse.toLowerCase().contains("session")) {
-          logger.lifecycle("\nPrevious Azkaban session expired. Please re-login.");
-          cancelRunningAzkabanFlow(null);
-        } else {
-          // If response contains other than session error
-          logger.error("Fetching flows from ${azkProject.azkabanUrl} failed. Reason: " + new JSONObject(fetchFlowsResponse).get("error").toString());
-        }
+    if (fetchFlowsResponse.toLowerCase().contains("error")) {
+      // Check if session has expired. If so, re-login.
+      if (fetchFlowsResponse.toLowerCase().contains("session")) {
+        logger.lifecycle("\nPrevious Azkaban session expired. Please re-login.");
+        cancelRunningAzkabanFlow(null);
         return;
       }
 
-      List<String> flows = AzkabanHelper.fetchSortedFlows(new JSONObject(fetchFlowsResponse));
-      if (flows.isEmpty()) {
-        logger.lifecycle("No flows defined in current project");
+      // If response contains other than session error
+      String msg = "Fetching flows from ${azkProject.azkabanUrl} failed. Reason: " + new JSONObject(fetchFlowsResponse).get("error").toString();
+      throw new GradleException(msg);
+    }
+
+    List<String> flows = AzkabanHelper.fetchSortedFlows(new JSONObject(fetchFlowsResponse));
+    if (flows.isEmpty()) {
+      logger.lifecycle("No flows defined in current project");
+      return;
+    }
+
+    // Pool HTTP GET requests for getting running execution ID's of each flow
+    List responseList = AzkabanClient.batchGetRunningExecutions(azkProject.azkabanUrl, azkProject.azkabanProjName, flows, sessionId);
+    List<String> execIds = new ArrayList<String>();
+
+    responseList.each { execResponse ->
+      JSONObject execIDResponse = new JSONObject(execResponse);
+      if (execIDResponse.has("error")) {
+        logger.error("Could not get flow due to ${execIDResponse.get("error").toString()}");
+      } else if (execIDResponse.has("execIds")) {
+        JSONArray execArray = execIDResponse.getJSONArray("execIds");
+        if (execArray != null) {
+          for (int i = 0; i < execArray.length(); i++) {
+            execIds.add(execArray.get(i).toString());
+          }
+        }
+      }
+    }
+
+    if (execIds.isEmpty()) {
+      logger.lifecycle("\nProject " + azkProject.azkabanProjName + " has no running flows to kill.");
+      return;
+    }
+
+    Set<String> runningExecSet;
+
+    if (AzkabanPlugin.interactive) {
+      // Pool HTTP GET requests for getting exec Job statuses
+      responseList = AzkabanClient.batchFetchFlowExecution(azkProject.azkabanUrl, execIds, sessionId);
+      printStatus(flows, responseList);
+
+      // Get exec ID's to kill
+      def console = AzkabanHelper.getSystemConsole();
+      String input = AzkabanHelper.consoleInput(console, " > Enter ID's of executions to be killed: ", true);
+
+      if (input.isEmpty()) {
+        logger.error("Nothing entered, exiting...");
         return;
       }
 
-      //Pool HTTP Get requests for getting Running ExecIDs of each flow
-      List responseList = AzkabanClient.batchGetRunningExecutions(azkProject.azkabanUrl, azkProject.azkabanProjName, flows, sessionId);
-
-      List<String> execIds = new ArrayList<String>();
-      responseList.each { execResponse ->
-        JSONObject execIDResponse = new JSONObject(execResponse);
-        if (execIDResponse.has("error")) {
-          logger.error("Could not get flow due to ${execIDResponse.get("error").toString()}");
-        } else if (execIDResponse.has("execIds")) {
-          JSONArray execArray = execIDResponse.getJSONArray("execIds");
-          if (execArray != null) {
-            for (int i=0; i<execArray.length(); i++) {
-              execIds.add(execArray.get(i).toString());
-            }
-          }
-        }
-      }
-
-      if (!execIds.isEmpty()) {
-        Set<String> runningExecSet;
-
-        if (AzkabanPlugin.interactive) {
-          //Pool HTTP Get requests for getting exec Job statuses
-          responseList = AzkabanClient.batchFetchFlowExecution(azkProject.azkabanUrl, execIds, sessionId);
-          printStatus(flows, responseList);
-
-          //Get exec ID's to kill
-          String input =  AzkabanHelper.consoleInput(System.console(), " > Enter IDs of executions to be killed:", true);
-          if(input.isEmpty()) {
-            logger.error("Entered Nothing, Exiting...");
+      runningExecSet = new HashSet<String>(Arrays.asList(input.split("\\D+")));
+      if (runningExecSet != null && !runningExecSet.isEmpty()) {
+        runningExecSet.sort();
+        // Check if entered execIds are from this project
+        for (String runningExec: runningExecSet) {
+          if (!execIds.contains(runningExec)) {
+            logger.error("Enter execution ID's from current project");
             return;
           }
-
-          runningExecSet = new HashSet<String>(Arrays.asList(input.split("\\D+")));
-          if (runningExecSet != null && !runningExecSet.isEmpty()) {
-            runningExecSet.sort();
-            //Check if entered execIds are from this project
-            for (String runningExec: runningExecSet) {
-              if (!execIds.contains(runningExec)) {
-                logger.error("Enter execution IDs from current project");
-                return;
-              }
-            }
-          } else {
-            logger.error("Empty indices");
-            return;
-          }
-        } else {
-          List<String> execs = project.getProperties().get("execId").toString().split(",+");
-          runningExecSet = new HashSet<String>();
-
-          for (String exec : execs) {
-            runningExecSet.add(exec);
-          }
         }
-
-        if (!runningExecSet.isEmpty()) {
-          //Pool HTTP Get requests for killing flows
-          responseList = AzkabanClient.batchCancelFlowExecution(azkProject.azkabanUrl, runningExecSet, sessionId);
-
-          for (String killResponse : responseList) {
-            JSONObject killResponseObj = new JSONObject(killResponse);
-            if (killResponseObj.has("error")) {
-              logger.error(killResponseObj.get("error").toString());
-            } else {
-              logger.lifecycle("Successfully killed flow execution");
-            }
-          }
-        } else {
-          logger.lifecycle("Entered no execution Ids");
-        }
-
       } else {
-        logger.lifecycle("\nProject " + azkProject.azkabanProjName + " has no running flows to kill.");
+        logger.error("Empty indices");
+        return;
       }
+    } else {
+      List<String> execs = project.getProperties().get("execId").toString().split(",+");
+      runningExecSet = new HashSet<String>();
+      for (String exec : execs) {
+        runningExecSet.add(exec);
+      }
+    }
 
-    } catch (IOException ex) {
-      ex.printStackTrace();
+    if (runningExecSet.isEmpty()) {
+      logger.lifecycle("Entered no execution ID's");
+      return;
+    }
+
+    // Pool HTTP GET requests for killing flows
+    responseList = AzkabanClient.batchCancelFlowExecution(azkProject.azkabanUrl, runningExecSet, sessionId);
+
+    for (String killResponse : responseList) {
+      JSONObject killResponseObj = new JSONObject(killResponse);
+      if (killResponseObj.has("error")) {
+        logger.error(killResponseObj.get("error").toString());
+      } else {
+        logger.lifecycle("Successfully killed flow execution");
+      }
     }
   }
 
   void printStatus(List<String> flows, List<String> responseList) {
-    //Print the status
     logger.lifecycle("-------------------");
     logger.lifecycle("FLOW RUNNING STATUS");
     logger.lifecycle("-------------------\n");
 
     flows.each { flow ->
-      for(int j=0; j<responseList.size(); j++) {
+      for (int j = 0; j < responseList.size(); j++) {
         String jobResponse = responseList.get(j);
         JSONObject jobsObject = new JSONObject(jobResponse);
 
         if(flow.equals(jobsObject.get("flow"))) {
-
           String execid = jobsObject.get("execid").toString();
-          //String flowStatus = jobsObject.get("status").toString();
+          // String flowStatus = jobsObject.get("status").toString();
           String flowSubmitTime = AzkabanClientUtil.epochToDate(jobsObject.get("submitTime").toString());
           String flowStartTime = AzkabanClientUtil.epochToDate(jobsObject.get("startTime").toString());
-          //String flowEndTime = AzkabanClientUtil.epochToDate(jobsObject.get("endTime").toString());
+          // String flowEndTime = AzkabanClientUtil.epochToDate(jobsObject.get("endTime").toString());
           String flowElapsedTime = AzkabanClientUtil.getElapsedTime(jobsObject.get("startTime").toString(), jobsObject.get("endTime").toString());
 
           System.out.println("Flow: ${flow} | Exec Id: ${execid} | Submitted: ${flowSubmitTime} | Started: ${flowStartTime} | Elapsed: ${flowElapsedTime}");

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
@@ -176,7 +176,7 @@ class AzkabanPlugin implements Plugin<Project> {
         azkProject = readAzkabanProject(project, false);
 
         if (project.hasProperty("flow")) {
-          logger.lifecycle("Displaying Job level Status");
+          logger.lifecycle("Displaying job level status");
           interactive = false;
         }
       }
@@ -325,15 +325,16 @@ class AzkabanPlugin implements Plugin<Project> {
    * @return The created AzkabanProject
    */
   AzkabanProject readAzkabanProject(Project project, boolean interactive) {
-    AzkabanProject azkabanProject = AzkabanHelper.
-        readAzkabanProjectFromJson(project, getPluginJsonPath(project));
+    AzkabanProject azkabanProject = AzkabanHelper.readAzkabanProjectFromJson(project, getPluginJsonPath(project));
+
     if (azkabanProject == null) {
-      azkabanProject = AzkabanHelper.
-          readAzkabanProjectFromInteractiveConsole(project, makeDefaultAzkabanProject(project),
-              getPluginJsonPath(project));
+      azkabanProject = AzkabanHelper.readAzkabanProjectFromInteractiveConsole(project,
+          makeDefaultAzkabanProject(project), getPluginJsonPath(project));
     } else if (interactive) {
-      azkabanProject = AzkabanHelper.readAzkabanProjectFromInteractiveConsole(project, azkabanProject, getPluginJsonPath(project));
+      azkabanProject = AzkabanHelper.readAzkabanProjectFromInteractiveConsole(project, azkabanProject,
+          getPluginJsonPath(project));
     }
+
     return azkabanProject;
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/test/TestPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/test/TestPlugin.groovy
@@ -404,8 +404,6 @@ class TestPlugin extends HadoopDslPlugin implements Plugin<Project> {
     AzkabanHelper.printFlowExecutionResponses(responseList);
   }
 
-
-
   /**
    * Returns a list of all flows in project azkProject.azkabanProjName.
    *


### PR DESCRIPTION
This Pull Request makes numerous minor fixes to the Azkaban CLI tasks (and one for the Hadoop Validator), including:
* Missing jar required by the Apache Pig Validator
* Wrong or missing return types for functions
* Tasks using the System console do not consistently tell the user about the JAVA_HOME issue
* Tasks getting password input from the System console do not follow the best practice of clearing the password array after it has been used
* Other minor errors affecting the CLI tasks