### PR TITLE
LIHADOOP-26107 Parameters to override the setting in .azkabanPlugin.json

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -84,6 +84,7 @@ The following were contributed by Ragesh Rajagopalan. Thanks, Ragesh!
 * `DI-584 Login prompt missing when uploading to Azkaban`
 
 The following were contributed by Pranay Hasan Yerra. Thanks, Pranay!
+* `LIHADOOP-26107 Parameters to override the setting in .azkabanPlugin.json`
 * `LIHADOOP-16252 Prevent core-site.xml from polluting IDE's classpath`
 * `LIHADOOP-25566 Update Dr.Elephant URL link in azkabanFlowStatus task`
 * `LIHADOOP-25637 Check for trailing slash in AzkabanUrl when running azkabanUpload task`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,10 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+o.13.7
+
+* Parameters to override the setting in .azkabanPlugin.json
+
 0.13.6
 
 * Adding additional condition for TableauJob creation

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.13.6
+version=0.13.7

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanHelper.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanHelper.groovy
@@ -283,6 +283,28 @@ class AzkabanHelper {
   }
 
   /**
+   * Overrides the azkProject properties with properties passed from the Gradle project
+   * Used for overriding Azkaban Project's properties through -Pprop=value
+   *
+   * @param project The Gradle project
+   * @param azkProject The Azkaban project
+   */
+  static void overrideProjectProperties(Project project, AzkabanProject azkProject) {
+    if (project.hasProperty('azkabanProjName')) {
+      azkProject.azkabanProjName = project.property('azkabanProjName')
+    }
+    if (project.hasProperty('azkabanUrl')) {
+      azkProject.azkabanUrl = project.property('azkabanUrl')
+    }
+    if (project.hasProperty('azkabanUserName')) {
+      azkProject.azkabanUserName = project.property('azkabanUserName')
+    }
+    if (project.hasProperty('azkabanZipTask')) {
+      azkProject.azkabanZipTask = project.property('azkabanZipTask')
+    }
+  }
+
+  /**
    * Helper method to return the system console, or throw an exception with a helpful error message
    * if it cannot be accessed.
    *
@@ -548,10 +570,7 @@ class AzkabanHelper {
     AzkabanProject azkProject = new AzkabanProject();
 
     if (pluginJson != null) {
-      // If the file exists, the task should use this information, but give the user the chance
-      // to confirm or change the values read from the file. If the user changes this information,
-      // ask them if they want to save the changes (to the .azkabanPlugin.json file).
-      azkProject.azkabanProjName = pluginJson[AZK_PROJ_NAME];
+      azkProject.azkabanProjName = pluginJson[AZK_PROJ_NAME]
       azkProject.azkabanUrl = pluginJson[AZK_URL];
       azkProject.azkabanUserName = pluginJson[AZK_USER_NAME];
       azkProject.azkabanValidatorAutoFix = pluginJson[AZK_VAL_AUTO_FIX];

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
@@ -307,17 +307,22 @@ class AzkabanPlugin implements Plugin<Project> {
   }
 
   /**
-   * Reads the AzkabanProject from the .azkabanPlugin.json file or the interactive console
+   * Reads the AzkabanProject from the .azkabanPlugin.json file and overrides the values if users
+   * passes project properties.
+   *
    * @param project The Gradle project
+   * @param interactive Interactively asks users for project properties
    * @return The created AzkabanProject
    */
   AzkabanProject readAzkabanProject(Project project, boolean interactive) {
     AzkabanProject azkabanProject = AzkabanHelper.readAzkabanProjectFromJson(project, getPluginJsonPath(project));
-
+    // If .azkabanPlugin.json doesn't exist, create a default Azkaban Project
     if (azkabanProject == null) {
-      azkabanProject = AzkabanHelper.readAzkabanProjectFromInteractiveConsole(project,
-          makeDefaultAzkabanProject(project), getPluginJsonPath(project));
-    } else if (interactive) {
+      azkabanProject = makeDefaultAzkabanProject(project)
+    }
+    AzkabanHelper.overrideProjectProperties(project, azkabanProject);
+
+    if (interactive) {
       azkabanProject = AzkabanHelper.readAzkabanProjectFromInteractiveConsole(project, azkabanProject,
           getPluginJsonPath(project));
     }


### PR DESCRIPTION
This is a long pending item and resolves #110 

**Details**
Users can run ./gradle azkabanUpload task with the one/multiple of the following additional parameters which override the values in .azkabanPlugin.json

- `-PazkabanUrl=https://<overridden_azkaban_instance>:<port>`
- `-PazkabanProjName=overriddenProjName`
- `-PazkabanZipTask=overriddenZipTaskName`
- `-PazkabanUserName=overriddenUserName`

So, this functionality enables users to use azkabanUpload task to override the above mentioned properties in .azkabanPlugin.json without manually editing the file for uploading to multiple instanaces, if any.