### PR TITLE
session ids are stored separately for each azkaban server

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -127,3 +127,7 @@ The following were contributed by Nicholas Cowan. Thanks, Nick!
 
 The following were contributed by Charles Gao. Thanks, Charles!
 * `Add ability for Hadoop DSL to understand the VenicePushJob job type`
+
+The following were contributed by Michal Trna. Thanks, Michal!
+* `Session IDs are stored separately for each Azkaban server`
+

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,10 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.14.2
+
+* Session IDs are stored separately for each Azkaban server.  
+
 0.14.1
 
 * Addressed a bug in ready status. Cleaned up the codenarc errors in azkaban-client.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.14.1
+version=0.14.2

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanBlockedFlowStatusTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanBlockedFlowStatusTask.groovy
@@ -36,7 +36,7 @@ class AzkabanBlockedFlowStatusTask extends AzkabanFlowStatusTask {
     if (azkProject.azkabanUrl == null) {
       throw new GradleException("Please set azkaban.url in the .azkabanPlugin.json file in your project directory.");
     }
-    getBlockedAzkabanFlowStatus(AzkabanHelper.readSession());
+    getBlockedAzkabanFlowStatus(AzkabanHelper.readSession(azkProject.azkabanUrl));
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCancelFlowTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCancelFlowTask.groovy
@@ -40,7 +40,7 @@ class AzkabanCancelFlowTask extends DefaultTask {
     if (azkProject.azkabanUrl == null) {
       throw new GradleException("Please set azkaban.url in the .azkabanPlugin.json file in your project directory.");
     }
-    cancelRunningAzkabanFlow(AzkabanHelper.readSession());
+    cancelRunningAzkabanFlow(AzkabanHelper.readSession(azkProject.azkabanUrl));
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCreateProjectTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCreateProjectTask.groovy
@@ -37,7 +37,7 @@ class AzkabanCreateProjectTask extends DefaultTask {
     if (azkProject.azkabanUrl == null) {
       throw new GradleException("Please set azkaban.url in the .azkabanPlugin.json file in your project directory.");
     }
-    createAzkabanProject(AzkabanHelper.readSession());
+    createAzkabanProject(AzkabanHelper.readSession(azkProject.azkabanUrl));
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanExecuteFlowTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanExecuteFlowTask.groovy
@@ -38,7 +38,7 @@ class AzkabanExecuteFlowTask extends DefaultTask {
     if (azkProject.azkabanUrl == null) {
       throw new GradleException("Please set azkaban.url in the .azkabanPlugin.json file in your project directory.");
     }
-    executeAzkabanFlow(AzkabanHelper.readSession());
+    executeAzkabanFlow(AzkabanHelper.readSession(azkProject.azkabanUrl));
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanFlowStatusTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanFlowStatusTask.groovy
@@ -41,7 +41,7 @@ class AzkabanFlowStatusTask extends DefaultTask {
     if (azkProject.azkabanUrl == null) {
       throw new GradleException("Please set azkaban.url in the .azkabanPlugin.json file in your project directory.");
     }
-    getAzkabanFlowStatus(AzkabanHelper.readSession());
+    getAzkabanFlowStatus(AzkabanHelper.readSession(azkProject.azkabanUrl));
   }
 
   /**
@@ -114,7 +114,7 @@ class AzkabanFlowStatusTask extends DefaultTask {
     }
 
     // The user may have had to re-login to Azkaban, so re-read the session ID
-    sessionId = AzkabanHelper.readSession()
+    sessionId = AzkabanHelper.readSession(azkProject.azkabanUrl)
 
     // List of all the recent execution ID's of the flows defined in the project
     List<String> execIds = getRecentFlowExecutionIds(sessionId, flows);

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanUploadTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanUploadTask.groovy
@@ -53,7 +53,7 @@ class AzkabanUploadTask extends DefaultTask {
     if (azkProject.azkabanUrl == null) {
       throw new GradleException("Please set azkaban.url in the .azkabanPlugin.json file in your project directory.");
     }
-    authenticateAndUploadToAzkaban(AzkabanHelper.readSession());
+    authenticateAndUploadToAzkaban(AzkabanHelper.readSession(azkProject.azkabanUrl));
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/test/TestPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/test/TestPlugin.groovy
@@ -265,8 +265,8 @@ class TestPlugin extends HadoopDslPlugin implements Plugin<Project> {
 
         String message = " The test project on Azkaban is ${azkProject.azkabanProjName}. Your test will be run in ${azkProject.azkabanProjName}";
         prettyPrintMessage(message);
-        List<String> testWorkflows = getTestWorkflows(project, AzkabanHelper.resumeOrGetSession(AzkabanHelper.readSession(), azkProject), azkProject);
-        executeAzkabanFlow(project, AzkabanHelper.readSession(), testWorkflows, azkProject);
+        List<String> testWorkflows = getTestWorkflows(project, AzkabanHelper.resumeOrGetSession(AzkabanHelper.readSession("http://example.com:123"), azkProject), azkProject);
+        executeAzkabanFlow(project, AzkabanHelper.readSession("http://example.com:123"), testWorkflows, azkProject);
       }
     }
   }
@@ -294,8 +294,8 @@ class TestPlugin extends HadoopDslPlugin implements Plugin<Project> {
 
         String message = " The test project on Azkaban is ${azkProject.azkabanProjName}. Your assertions will be run in ${azkProject.azkabanProjName}";
         prettyPrintMessage(message);
-        List<String> testWorkflows = getAssertionWorkflows(project, AzkabanHelper.resumeOrGetSession(AzkabanHelper.readSession(), azkProject), azkProject);
-        executeAzkabanFlow(project, AzkabanHelper.readSession(), testWorkflows, azkProject);
+        List<String> testWorkflows = getAssertionWorkflows(project, AzkabanHelper.resumeOrGetSession(AzkabanHelper.readSession("http://example.com:123"), azkProject), azkProject);
+        executeAzkabanFlow(project, AzkabanHelper.readSession("http://example.com:123"), testWorkflows, azkProject);
       }
     }
   }
@@ -455,7 +455,7 @@ class TestPlugin extends HadoopDslPlugin implements Plugin<Project> {
         validateTestnameProperty(project);
 
         azkProject = getTestProjectName(project, false);
-        List<String> testflows = filterTestFlows(getFlowsOrThrowError(project, AzkabanHelper.readSession(), azkProject), project);
+        List<String> testflows = filterTestFlows(getFlowsOrThrowError(project, AzkabanHelper.readSession("http://example.com:123"), azkProject), project);
         flowsToExecute = testflows;
 
         String message = " The test project on Azkaban is ${azkProject.azkabanProjName}. Your test status will be fetched from ${azkProject.azkabanProjName}";
@@ -486,7 +486,7 @@ class TestPlugin extends HadoopDslPlugin implements Plugin<Project> {
         validateTestnameProperty(project);
 
         azkProject = getTestProjectName(project, false);
-        List<String> testflows = filterAssertionFlows(getFlowsOrThrowError(project, AzkabanHelper.readSession(), azkProject), project);
+        List<String> testflows = filterAssertionFlows(getFlowsOrThrowError(project, AzkabanHelper.readSession("http://example.com:123"), azkProject), project);
         flowsToExecute = testflows;
 
         if(flowsToExecute.empty) {


### PR DESCRIPTION
Hi! I would like to improve the handling of the session ids a bit.
current master: only one session id for the last Azkaban contacted is stored
proposed change: each Azkaban has its separate file, where session id and timestamp of its retrieval is stored
expected benefits: Azkaban sessions are preserved when working with multiple Azkabans; old session ids are not used; users should see less of unnecessary authentication errors.