### PR TITLE
Second PR for Yaml output for Flow 2.0

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -117,6 +117,7 @@ The following were contributed by Jianling Zhong. Thanks, Jianling!
 * `Add supports for a "required parameters" check`
 
 The following were contributed by Charlie Summers. Thanks, Charlie!
+* `Allow configurable Yaml creation for Flow 2.0`
 * `Introduce YamlCompiler, YamlWorkflow, YamlJob, and YamlProject for Flow 2.0`
 * `Add ability for Hadoop DSL to understand the TableauJob job type`
 * `Adding additional condition for TableauJob creation`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -20,6 +20,7 @@ version bump, so you will see a few skipped version numbers in the list below.
 0.14.3
 
 * Introduce YamlCompiler, YamlWorkflow, YamlJob, and YamlProject for Flow 2.0
+* Allow configurable Yaml creation for Flow 2.0
 
 0.14.2
 

--- a/hadoop-plugin-test/expectedJobs/basicFlow/basicFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/basicFlow/basicFlow.flow
@@ -1,0 +1,25 @@
+config:
+  flow-level-parameter: value
+nodes:
+- name: basicFlow
+  type: noop
+  dependsOn:
+  - shellEnd
+- name: shellEnd
+  type: noop
+  dependsOn:
+  - shellPwd
+  - shellEcho
+  - shellBash
+- name: shellPwd
+  type: command
+  config:
+    command: pwd
+- name: shellEcho
+  type: command
+  config:
+    command: echo "This is an echoed text."
+- name: shellBash
+  type: command
+  config:
+    command: bash ./sample_script.sh

--- a/hadoop-plugin-test/expectedJobs/basicFlow/basicFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/basicFlow/basicFlow.flow
@@ -4,10 +4,6 @@ nodes:
 - name: basicFlow
   type: noop
   dependsOn:
-  - shellEnd
-- name: shellEnd
-  type: noop
-  dependsOn:
   - shellPwd
   - shellEcho
   - shellBash

--- a/hadoop-plugin-test/expectedJobs/basicFlow/hadoop-plugin-test.project
+++ b/hadoop-plugin-test/expectedJobs/basicFlow/hadoop-plugin-test.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/hadoop-plugin-test/expectedJobs/basicFlowMultiple/basicFlow1.flow
+++ b/hadoop-plugin-test/expectedJobs/basicFlowMultiple/basicFlow1.flow
@@ -1,0 +1,25 @@
+config:
+  flow-level-parameter: value
+nodes:
+- name: basicFlow1
+  type: noop
+  dependsOn:
+  - shellEnd
+- name: shellEnd
+  type: noop
+  dependsOn:
+  - shellPwd
+  - shellEcho
+  - shellBash
+- name: shellPwd
+  type: command
+  config:
+    command: pwd
+- name: shellEcho
+  type: command
+  config:
+    command: echo "This is an echoed text."
+- name: shellBash
+  type: command
+  config:
+    command: bash ./sample_script.sh

--- a/hadoop-plugin-test/expectedJobs/basicFlowMultiple/basicFlow1.flow
+++ b/hadoop-plugin-test/expectedJobs/basicFlowMultiple/basicFlow1.flow
@@ -4,10 +4,6 @@ nodes:
 - name: basicFlow1
   type: noop
   dependsOn:
-  - shellEnd
-- name: shellEnd
-  type: noop
-  dependsOn:
   - shellPwd
   - shellEcho
   - shellBash

--- a/hadoop-plugin-test/expectedJobs/basicFlowMultiple/basicFlow2.flow
+++ b/hadoop-plugin-test/expectedJobs/basicFlowMultiple/basicFlow2.flow
@@ -4,10 +4,6 @@ nodes:
 - name: basicFlow2
   type: noop
   dependsOn:
-  - shellEnd
-- name: shellEnd
-  type: noop
-  dependsOn:
   - shellPwd
   - shellEcho
   - shellBash

--- a/hadoop-plugin-test/expectedJobs/basicFlowMultiple/basicFlow2.flow
+++ b/hadoop-plugin-test/expectedJobs/basicFlowMultiple/basicFlow2.flow
@@ -1,0 +1,25 @@
+config:
+  flow-level-parameter: value
+nodes:
+- name: basicFlow2
+  type: noop
+  dependsOn:
+  - shellEnd
+- name: shellEnd
+  type: noop
+  dependsOn:
+  - shellPwd
+  - shellEcho
+  - shellBash
+- name: shellPwd
+  type: command
+  config:
+    command: pwd
+- name: shellEcho
+  type: command
+  config:
+    command: echo "This is an echoed text."
+- name: shellBash
+  type: command
+  config:
+    command: bash ./sample_script.sh

--- a/hadoop-plugin-test/expectedJobs/basicFlowMultiple/hadoop-plugin-test.project
+++ b/hadoop-plugin-test/expectedJobs/basicFlowMultiple/hadoop-plugin-test.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/hadoop-plugin-test/expectedJobs/basicFlowNotYaml/basicFlowNotYaml.job
+++ b/hadoop-plugin-test/expectedJobs/basicFlowNotYaml/basicFlowNotYaml.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=noop
+dependencies=basicFlowNotYaml_shellPwd,basicFlowNotYaml_shellEcho,basicFlowNotYaml_shellBash

--- a/hadoop-plugin-test/expectedJobs/basicFlowNotYaml/basicFlowNotYaml_properties.properties
+++ b/hadoop-plugin-test/expectedJobs/basicFlowNotYaml/basicFlowNotYaml_properties.properties
@@ -1,0 +1,2 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+flow-level-parameter=value

--- a/hadoop-plugin-test/expectedJobs/basicFlowNotYaml/basicFlowNotYaml_shellBash.job
+++ b/hadoop-plugin-test/expectedJobs/basicFlowNotYaml/basicFlowNotYaml_shellBash.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=command
+command=bash ./sample_script.sh

--- a/hadoop-plugin-test/expectedJobs/basicFlowNotYaml/basicFlowNotYaml_shellEcho.job
+++ b/hadoop-plugin-test/expectedJobs/basicFlowNotYaml/basicFlowNotYaml_shellEcho.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=command
+command=echo "This is an echoed text."

--- a/hadoop-plugin-test/expectedJobs/basicFlowNotYaml/basicFlowNotYaml_shellPwd.job
+++ b/hadoop-plugin-test/expectedJobs/basicFlowNotYaml/basicFlowNotYaml_shellPwd.job
@@ -1,0 +1,3 @@
+# This file generated from the Hadoop DSL. Do not edit by hand.
+type=command
+command=pwd

--- a/hadoop-plugin-test/expectedJobs/embeddedFlow/embeddedFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/embeddedFlow/embeddedFlow.flow
@@ -1,0 +1,62 @@
+config:
+  flow-level-parameter: value
+nodes:
+- name: embeddedFlow
+  type: noop
+  dependsOn:
+  - shellEnd
+- name: shellEnd
+  type: noop
+  dependsOn:
+  - shellPwd
+  - shellEcho
+  - embeddedFlow1
+- name: shellPwd
+  type: command
+  config:
+    command: pwd
+- name: shellEcho
+  type: command
+  config:
+    command: echo "This is an echoed text."
+- name: embeddedFlow1
+  type: flow
+  config:
+    flow-level-parameter: value
+  nodes:
+  - name: embeddedFlow1
+    type: noop
+    dependsOn:
+    - shellEnd
+  - name: shellEnd
+    type: noop
+    dependsOn:
+    - shellEcho
+    - embeddedFlow2
+  - name: shellEcho
+    type: command
+    config:
+      command: echo "This is an echoed text from embeddedFlow1."
+  - name: shellBash
+    type: command
+    config:
+      command: bash ./sample_script.sh
+  - name: embeddedFlow2
+    type: flow
+    dependsOn:
+    - shellBash
+    config:
+      flow-level-parameter: value
+    nodes:
+    - name: embeddedFlow2
+      type: noop
+      dependsOn:
+      - shellEnd
+    - name: shellEnd
+      type: noop
+      dependsOn:
+      - shellPwd
+    - name: shellPwd
+      type: command
+      config:
+        command: pwd

--- a/hadoop-plugin-test/expectedJobs/embeddedFlow/embeddedFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/embeddedFlow/embeddedFlow.flow
@@ -4,10 +4,6 @@ nodes:
 - name: embeddedFlow
   type: noop
   dependsOn:
-  - shellEnd
-- name: shellEnd
-  type: noop
-  dependsOn:
   - shellPwd
   - shellEcho
   - embeddedFlow1
@@ -25,10 +21,6 @@ nodes:
     flow-level-parameter: value
   nodes:
   - name: embeddedFlow1
-    type: noop
-    dependsOn:
-    - shellEnd
-  - name: shellEnd
     type: noop
     dependsOn:
     - shellEcho
@@ -49,10 +41,6 @@ nodes:
       flow-level-parameter: value
     nodes:
     - name: embeddedFlow2
-      type: noop
-      dependsOn:
-      - shellEnd
-    - name: shellEnd
       type: noop
       dependsOn:
       - shellPwd

--- a/hadoop-plugin-test/expectedJobs/embeddedFlow/hadoop-plugin-test.project
+++ b/hadoop-plugin-test/expectedJobs/embeddedFlow/hadoop-plugin-test.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/hadoop-plugin-test/expectedJobs/loadPropsFlow/hadoop-plugin-test.project
+++ b/hadoop-plugin-test/expectedJobs/loadPropsFlow/hadoop-plugin-test.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/hadoop-plugin-test/expectedJobs/loadPropsFlow/loadPropsFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/loadPropsFlow/loadPropsFlow.flow
@@ -1,0 +1,52 @@
+config:
+  props3: moo3
+  props4: moo4
+  props5: moo5
+  props1: shared1
+  props2: shared2
+  props6: shared6
+nodes:
+- name: loadPropsFlow
+  type: noop
+  dependsOn:
+  - job3
+- name: job3
+  type: noop
+  dependsOn:
+  - innerflow
+  config:
+    props3: job3
+- name: job2
+  type: noop
+  config:
+    props4: shared4
+    props8: shared8
+    props2: job2
+    props7: job7
+- name: innerflow
+  type: flow
+  dependsOn:
+  - job2
+  config:
+    props5: innerflow5
+    props6: innerflow6
+    props8: innerflow8
+  nodes:
+  - name: innerflow
+    type: noop
+    dependsOn:
+    - job4
+  - name: job4
+    type: noop
+    dependsOn:
+    - job1
+    config:
+      props4: shared4
+      props8: job8
+      props9: job9
+  - name: job1
+    type: noop
+    config:
+      props1: job1
+      props2: job2
+      props8: job8

--- a/hadoop-plugin-test/expectedOutput/positive/basicFlow.out
+++ b/hadoop-plugin-test/expectedOutput/positive/basicFlow.out
@@ -1,0 +1,4 @@
+:hadoop-plugin-test:test_basicFlow
+Running test for the file positive/basicFlow.gradle
+Hadoop DSL static checker PASSED
+

--- a/hadoop-plugin-test/expectedOutput/positive/basicFlowMultiple.out
+++ b/hadoop-plugin-test/expectedOutput/positive/basicFlowMultiple.out
@@ -1,0 +1,4 @@
+:hadoop-plugin-test:test_basicFlowMultiple
+Running test for the file positive/basicFlowMultiple.gradle
+Hadoop DSL static checker PASSED
+

--- a/hadoop-plugin-test/expectedOutput/positive/basicFlowNotYaml.out
+++ b/hadoop-plugin-test/expectedOutput/positive/basicFlowNotYaml.out
@@ -1,0 +1,4 @@
+:hadoop-plugin-test:test_basicFlowNotYaml
+Running test for the file positive/basicFlowNotYaml.gradle
+Hadoop DSL static checker PASSED
+

--- a/hadoop-plugin-test/expectedOutput/positive/embeddedFlow.out
+++ b/hadoop-plugin-test/expectedOutput/positive/embeddedFlow.out
@@ -1,0 +1,4 @@
+:hadoop-plugin-test:test_embeddedFlow
+Running test for the file positive/embeddedFlow.gradle
+Hadoop DSL static checker PASSED
+

--- a/hadoop-plugin-test/expectedOutput/positive/loadPropsFlow.out
+++ b/hadoop-plugin-test/expectedOutput/positive/loadPropsFlow.out
@@ -1,0 +1,6 @@
+:hadoop-plugin-test:test_loadPropsFlow
+Running test for the file positive/loadPropsFlow.gradle
+RequiredFieldsChecker WARNING: NoOpJob job2 does not declare any dependencies. It won't do anything.
+RequiredFieldsChecker WARNING: NoOpJob job1 does not declare any dependencies. It won't do anything.
+Hadoop DSL static checker PASSED
+

--- a/hadoop-plugin-test/src/main/gradle/positive/basicFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/basicFlow.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
 
-// Simple flow for testing yaml creation for flow 2.0
+// Simple flow for testing yaml creation for Flow 2.0
 
 hadoop {
   buildPath "jobs/basicFlow"

--- a/hadoop-plugin-test/src/main/gradle/positive/basicFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/basicFlow.gradle
@@ -38,10 +38,6 @@ hadoop {
       uses 'echo "This is an echoed text."'
     }
 
-    noOpJob('shellEnd') {
-      depends 'shellPwd', 'shellEcho', 'shellBash'
-    }
-
-    targets 'shellEnd'
+    targets 'shellPwd', 'shellEcho', 'shellBash'
   }
 }

--- a/hadoop-plugin-test/src/main/gradle/positive/basicFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/basicFlow.gradle
@@ -1,0 +1,47 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Simple flow for testing yaml creation for flow 2.0
+
+hadoop {
+  buildPath "jobs/basicFlow"
+  cleanPath false
+
+  generateYamlOutput true
+
+  workflow('basicFlow') {
+    propertyFile('properties') {
+      set properties: [
+              'flow-level-parameter' : 'value'
+      ]
+    }
+
+    commandJob('shellBash') {
+      uses 'bash ./sample_script.sh'
+    }
+
+    commandJob('shellPwd') {
+      uses 'pwd'
+    }
+
+    commandJob('shellEcho') {
+      uses 'echo "This is an echoed text."'
+    }
+
+    noOpJob('shellEnd') {
+      depends 'shellPwd', 'shellEcho', 'shellBash'
+    }
+
+    targets 'shellEnd'
+  }
+}

--- a/hadoop-plugin-test/src/main/gradle/positive/basicFlowMultiple.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/basicFlowMultiple.gradle
@@ -1,0 +1,73 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Simple flow for testing yaml creation for flow 2.0
+
+hadoop {
+  buildPath "jobs/basicFlowMultiple"
+  cleanPath false
+
+  generateYamlOutput true
+
+  workflow('basicFlow1') {
+    propertyFile('properties') {
+      set properties: [
+              'flow-level-parameter' : 'value'
+      ]
+    }
+
+    commandJob('shellBash') {
+      uses 'bash ./sample_script.sh'
+    }
+
+    commandJob('shellPwd') {
+      uses 'pwd'
+    }
+
+    commandJob('shellEcho') {
+      uses 'echo "This is an echoed text."'
+    }
+
+    noOpJob('shellEnd') {
+      depends 'shellPwd', 'shellEcho', 'shellBash'
+    }
+
+    targets 'shellEnd'
+  }
+
+  workflow('basicFlow2') {
+    propertyFile('properties') {
+      set properties: [
+              'flow-level-parameter' : 'value'
+      ]
+    }
+
+    commandJob('shellBash') {
+      uses 'bash ./sample_script.sh'
+    }
+
+    commandJob('shellPwd') {
+      uses 'pwd'
+    }
+
+    commandJob('shellEcho') {
+      uses 'echo "This is an echoed text."'
+    }
+
+    noOpJob('shellEnd') {
+      depends 'shellPwd', 'shellEcho', 'shellBash'
+    }
+
+    targets 'shellEnd'
+  }
+}

--- a/hadoop-plugin-test/src/main/gradle/positive/basicFlowMultiple.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/basicFlowMultiple.gradle
@@ -38,11 +38,7 @@ hadoop {
       uses 'echo "This is an echoed text."'
     }
 
-    noOpJob('shellEnd') {
-      depends 'shellPwd', 'shellEcho', 'shellBash'
-    }
-
-    targets 'shellEnd'
+    targets 'shellPwd', 'shellEcho', 'shellBash'
   }
 
   workflow('basicFlow2') {
@@ -64,10 +60,6 @@ hadoop {
       uses 'echo "This is an echoed text."'
     }
 
-    noOpJob('shellEnd') {
-      depends 'shellPwd', 'shellEcho', 'shellBash'
-    }
-
-    targets 'shellEnd'
+    targets 'shellPwd', 'shellEcho', 'shellBash'
   }
 }

--- a/hadoop-plugin-test/src/main/gradle/positive/basicFlowMultiple.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/basicFlowMultiple.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
 
-// Simple flow for testing yaml creation for flow 2.0
+// Two simple flows for testing yaml creation for Flow 2.0
 
 hadoop {
   buildPath "jobs/basicFlowMultiple"

--- a/hadoop-plugin-test/src/main/gradle/positive/basicFlowNotYaml.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/basicFlowNotYaml.gradle
@@ -1,0 +1,43 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Simple flow for testing yaml creation for Flow 2.0
+
+hadoop {
+  buildPath "jobs"
+  cleanPath false
+
+  generateYamlOutput false
+
+  workflow('basicFlowNotYaml') {
+    propertyFile('properties') {
+      set properties: [
+              'flow-level-parameter' : 'value'
+      ]
+    }
+
+    commandJob('shellBash') {
+      uses 'bash ./sample_script.sh'
+    }
+
+    commandJob('shellPwd') {
+      uses 'pwd'
+    }
+
+    commandJob('shellEcho') {
+      uses 'echo "This is an echoed text."'
+    }
+
+    targets 'shellPwd', 'shellEcho', 'shellBash'
+  }
+}

--- a/hadoop-plugin-test/src/main/gradle/positive/embeddedFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/embeddedFlow.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
 
-// Simple flow for testing yaml creation for flow 2.0
+// A more complicated flow for testing yaml creation for Flow 2.0
 
 hadoop {
   buildPath "jobs/embeddedFlow"

--- a/hadoop-plugin-test/src/main/gradle/positive/embeddedFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/embeddedFlow.gradle
@@ -53,29 +53,17 @@ hadoop {
         addPropertyFile('properties') {
         }
 
-        noOpJob('shellEnd') {
-          depends 'shellPwd'
-        }
-
         commandJob('shellPwd') {
           uses 'pwd'
         }
 
         flowDepends 'shellBash'
-        targets 'shellEnd'
+        targets 'shellPwd'
       }
 
-      noOpJob('shellEnd') {
-        depends 'shellEcho', 'embeddedFlow2'
-      }
-
-      targets 'shellEnd'
+      targets 'shellEcho', 'embeddedFlow2'
     }
 
-    noOpJob('shellEnd') {
-      depends 'shellPwd', 'shellEcho', 'embeddedFlow1'
-    }
-
-    targets 'shellEnd'
+    targets 'shellPwd', 'shellEcho', 'embeddedFlow1'
   }
 }

--- a/hadoop-plugin-test/src/main/gradle/positive/embeddedFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/embeddedFlow.gradle
@@ -1,0 +1,81 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Simple flow for testing yaml creation for flow 2.0
+
+hadoop {
+  buildPath "jobs/embeddedFlow"
+  cleanPath false
+
+  generateYamlOutput true
+
+  propertyFile('properties') {
+    set properties: [
+            'flow-level-parameter' : 'value'
+    ]
+  }
+
+  workflow('embeddedFlow') {
+    addPropertyFile('properties') {
+    }
+
+    commandJob('shellPwd') {
+      uses 'pwd'
+    }
+
+    commandJob('shellEcho') {
+      uses 'echo "This is an echoed text."'
+    }
+
+    workflow('embeddedFlow1') {
+      addPropertyFile('properties') {
+      }
+
+      commandJob('shellEcho') {
+        uses 'echo "This is an echoed text from embeddedFlow1."'
+      }
+
+      commandJob('shellBash') {
+        uses 'bash ./sample_script.sh'
+      }
+
+      workflow('embeddedFlow2') {
+        addPropertyFile('properties') {
+        }
+
+        noOpJob('shellEnd') {
+          depends 'shellPwd'
+        }
+
+        commandJob('shellPwd') {
+          uses 'pwd'
+        }
+
+        flowDepends 'shellBash'
+        targets 'shellEnd'
+      }
+
+      noOpJob('shellEnd') {
+        depends 'shellEcho', 'embeddedFlow2'
+      }
+
+      targets 'shellEnd'
+    }
+
+    noOpJob('shellEnd') {
+      depends 'shellPwd', 'shellEcho', 'embeddedFlow1'
+    }
+
+    targets 'shellEnd'
+  }
+}

--- a/hadoop-plugin-test/src/main/gradle/positive/loadPropsFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/loadPropsFlow.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
 
-// Simple flow for testing yaml creation for flow 2.0
+// Flow with lots of properties for testing yaml creation for Flow 2.0
 
 hadoop {
   buildPath "jobs/loadPropsFlow"

--- a/hadoop-plugin-test/src/main/gradle/positive/loadPropsFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/loadPropsFlow.gradle
@@ -1,0 +1,87 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Simple flow for testing yaml creation for flow 2.0
+
+hadoop {
+  buildPath "jobs/loadPropsFlow"
+  cleanPath false
+
+  generateYamlOutput true
+
+  propertyFile('outsideProperties') {
+    set properties: [
+            'props3' : 'moo3',
+            'props4' : 'moo4',
+            'props5' : 'moo5'
+    ]
+  }
+
+  workflow('loadPropsFlow') {
+    propertyFile('properties') {
+      set properties: [
+              'props1' : 'shared1',
+              'props2' : 'shared2',
+              'props6' : 'shared6'
+      ]
+    }
+
+    noOpJob('job2') {
+      set properties: [
+              'props4' : 'shared4',
+              'props8' : 'shared8',
+              'props2' : 'job2',
+              'props7' : 'job7'
+      ]
+    }
+
+    workflow('innerflow') {
+      propertyFile('innerProperties') {
+        set properties: [
+                'props5' : 'innerflow5',
+                'props6' : 'innerflow6',
+                'props8' : 'innerflow8'
+        ]
+      }
+
+      noOpJob('job1') {
+        set properties: [
+                'props1' : 'job1',
+                'props2' : 'job2',
+                'props8' : 'job8'
+        ]
+      }
+
+      noOpJob('job4') {
+        set properties: [
+                'props4' : 'shared4',
+                'props8' : 'job8',
+                'props9' : 'job9'
+        ]
+        depends 'job1'
+      }
+
+      flowDepends 'job2'
+      targets 'job4'
+    }
+
+    noOpJob('job3') {
+      set properties: [
+              'props3' : 'job3'
+      ]
+      depends 'innerflow'
+    }
+
+    targets 'job3'
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslCompiler.groovy
@@ -68,7 +68,7 @@ class AzkabanDslCompiler extends BaseCompiler {
    * Nothing needs to be done when AzkabanDslCompiler is created.
    */
   @Override
-  void doAtCompilerCreation() {
+  void doOnceAfterCleaningBuildDirectory() {
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslCompiler.groovy
@@ -65,6 +65,13 @@ class AzkabanDslCompiler extends BaseCompiler {
   }
 
   /**
+   * Nothing needs to be done when AzkabanDslCompiler is created.
+   */
+  @Override
+  void doAtCompilerCreation() {
+  }
+
+  /**
    * Builds the namespace. Creates a subdirectory for everything under the namespace.
    *
    * @param namespace The namespace to build

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanPlugin.groovy
@@ -286,7 +286,7 @@ class AzkabanPlugin implements Plugin<Project> {
    * @return The HaodopDslCompiler
    */
   HadoopDslCompiler makeCompiler(Project project) {
-    return new AzkabanDslCompiler(project);
+    return project.extensions.hadoopDslPlugin.selectCompilerType(project);
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/yaml/YamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/yaml/YamlCompiler.groovy
@@ -76,6 +76,15 @@ class YamlCompiler extends BaseCompiler {
   }
 
   /**
+   * At creation of compiler, visit project.
+   * Only one project will ever exist per hadoop { } closure.
+   */
+  @Override
+  void doAtCompilerCreation() {
+    visitProject();
+  }
+
+  /**
    * Create and customize a Yaml object.
    * DumperOptions.FlowStyle.BLOCK indents the yaml in the expected, most readable way.
    *
@@ -91,7 +100,7 @@ class YamlCompiler extends BaseCompiler {
    * Instead of visiting properties, jobs, and propertySets as done in BaseNamedScopeContainer,
    * only visit workflows and namespaces.
    *
-   * Also visit the YamlProject for the YamlCompiler.
+   * Don't create any new directories - designed to be flat as opposed to nested dir structure.
    *
    * @param container The DSL element subclassing BaseNamedScopeContainer
    */
@@ -102,9 +111,6 @@ class YamlCompiler extends BaseCompiler {
 
     // Set the new parent scope
     this.parentScope = container.scope;
-
-    // Visit this single YamlProject
-    visitProject();
 
     // Visit each workflow
     container.workflows.each { Workflow workflow ->

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/yaml/YamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/yaml/YamlCompiler.groovy
@@ -80,7 +80,7 @@ class YamlCompiler extends BaseCompiler {
    * Only one project will ever exist per hadoop { } closure.
    */
   @Override
-  void doAtCompilerCreation() {
+  void doOnceAfterCleaningBuildDirectory() {
     visitProject();
   }
 

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseCompiler.groovy
@@ -73,6 +73,8 @@ abstract class BaseCompiler extends BaseVisitor implements HadoopDslCompiler {
     visitExtension(plugin.extension);
   }
 
+  abstract void doAtCompilerCreation();
+
   /**
    * Builds the Hadoop DSL extension, which builds the workflows and properties that have been
    * specified in the DSL and added to the extension with the hadoop { ... } DSL syntax.
@@ -107,6 +109,8 @@ abstract class BaseCompiler extends BaseVisitor implements HadoopDslCompiler {
     if (hadoop.cleanFirst) {
       cleanBuildDirectory(file);
     }
+
+    doAtCompilerCreation();
 
     // Visit the workflows and properties under the extension
     super.visitExtension(hadoop);

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseCompiler.groovy
@@ -73,7 +73,11 @@ abstract class BaseCompiler extends BaseVisitor implements HadoopDslCompiler {
     visitExtension(plugin.extension);
   }
 
-  abstract void doAtCompilerCreation();
+  /**
+   * Override this with a method that's supposed to run only once immediately after the build
+   * directory is cleaned.
+   */
+  abstract void doOnceAfterCleaningBuildDirectory();
 
   /**
    * Builds the Hadoop DSL extension, which builds the workflows and properties that have been
@@ -110,7 +114,7 @@ abstract class BaseCompiler extends BaseVisitor implements HadoopDslCompiler {
       cleanBuildDirectory(file);
     }
 
-    doAtCompilerCreation();
+    doOnceAfterCleaningBuildDirectory();
 
     // Visit the workflows and properties under the extension
     super.visitExtension(hadoop);

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
@@ -646,6 +646,30 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
   }
 
   /**
+   * Toggle on .flow/.project files generation instead of .job/.properties files
+   *
+   * @return The value of generate_yaml_output flag - always true
+   */
+  @HadoopDslMethod
+  boolean generateYamlOutput() {
+    this.scope.bind("generate_yaml_output", true);
+    return true;
+  }
+
+  /**
+   * Creates the task to toggle between .flow/.project files generation and .job/.properties files
+   * generation.
+   *
+   * @param boolean flag Boolean to which generate_yaml_output is set
+   * @return The value of generate_yaml_output flag - always true
+   */
+  @HadoopDslMethod
+  boolean generateYamlOutput(boolean flag) {
+    this.scope.bind("generate_yaml_output", flag);
+    return flag;
+  }
+
+  /**
    * DSL namespace method. Creates a Namespace in scope with the given name and configuration.
    * <p>
    * For ease of organizing the user's Gradle scripts, namespaces can be redeclared at the same

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
@@ -15,6 +15,8 @@
  */
 package com.linkedin.gradle.hadoopdsl;
 
+import com.linkedin.gradle.azkaban.AzkabanDslCompiler;
+import com.linkedin.gradle.azkaban.yaml.YamlCompiler;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
@@ -90,6 +92,9 @@ class HadoopDslPlugin extends BaseNamedScopeContainer implements Plugin<Project>
     project.extensions.add("evalHadoopClosure", this.&evalHadoopClosure);
     project.extensions.add("evalHadoopClosures", this.&evalHadoopClosures);
     project.extensions.add("hadoopClosure", this.&hadoopClosure);
+
+    // Add ability for users to toggle .job/.properties or .flow/.project output types
+    project.extensions.add("generateYamlOutput", this.&generateYamlOutput);
 
     // Add the extensions that expose the DSL to users. Specifically, expose all of the DSL
     // functions on the NamedScopeContainer interface.
@@ -500,5 +505,22 @@ class HadoopDslPlugin extends BaseNamedScopeContainer implements Plugin<Project>
       throw new Exception("No definitionSet with the name ${name} has been defined");
     }
     currentDefinitionSetName = name;
+  }
+
+  /**
+   * Based on whether or not the flag generate_yaml_output is set to true in the hadoop scope
+   * (i.e. within the hadoop { } closure), select between YamlCompiler and AzkabanDslCompiler.
+   *
+   * Default is AzkabanDslCompiler for now.
+   *
+   * Flag is called 'generate_yaml_output' because underscores are not allowed in the names of
+   * other Hadoop objects, so it is highly unlikely for there to be unintentional collisions.
+   *
+   * @param project The Gradle project
+   * @return The User-configured Compiler, default is AzkabanDslCompiler
+   */
+  HadoopDslCompiler selectCompilerType(Project project) {
+    return scope.lookup(".hadoop.generate_yaml_output") ?
+            new YamlCompiler(project) : new AzkabanDslCompiler(project);
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
@@ -36,6 +36,8 @@ class HadoopDslPlugin extends BaseNamedScopeContainer implements Plugin<Project>
   List<Closure> hadoopClosures;
   Map<String, Closure> namedHadoopClosures;
 
+  static final String GENERATE_YAML_OUTPUT_FLAG_LOCATION = ".hadoop.generate_yaml_output";
+
   /**
    * Constructor for the Hadoop DSL Plugin.
    */
@@ -520,7 +522,7 @@ class HadoopDslPlugin extends BaseNamedScopeContainer implements Plugin<Project>
    * @return The User-configured Compiler, default is AzkabanDslCompiler
    */
   HadoopDslCompiler selectCompilerType(Project project) {
-    return scope.lookup(".hadoop.generate_yaml_output") ?
+    return scope.lookup(GENERATE_YAML_OUTPUT_FLAG_LOCATION) ?
             new YamlCompiler(project) : new AzkabanDslCompiler(project);
   }
 }


### PR DESCRIPTION
This is the second and final PR related to this issue: #193 

This PR builds the interface users interact with to choose whether or not they want to output .flow/.project files or .job/.properties files. As stated in my prior PR (#196) the default is .job/.properties for now.

After this PR is merged (and subsequently released), users can specify that they want to output yaml by adding:
* `generateYamlOutput true` or
* `generateYamlOutput()`

in the hadoop closure within their gradle files.

The change to existing code to make this happen is only ~75 lines, the other 500 lines added are from adding 4 end-to-end tests that confirm basic functionality for Flow 2.0. These tests mirror those done on the Azkaban side to confirm proper uploading.
