### PR TITLE
Remove taskCommand in tensorflow job dsl

### DIFF
--- a/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job24.job
+++ b/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job24.job
@@ -9,7 +9,6 @@ num_ps=2
 num_workers=4
 ps_memory=2048
 ps_vcores=1
-task_command=./tf.py
 worker_env.ENV1=val1
 worker_env.ENV2=val2
 worker_gpus=2

--- a/hadoop-plugin-test/expectedOutput/negative/missingFields.out
+++ b/hadoop-plugin-test/expectedOutput/negative/missingFields.out
@@ -45,7 +45,6 @@ RequiredFieldsChecker ERROR: PinotBuildAndPushJob job18 must set tableName, inpu
 RequiredFieldsChecker ERROR: TableauJob job19 must set workbookName
 RequiredFieldsChecker ERROR: HdfsWaitJob job20 must set dirPath, freshness, timeout, and forceJobToFail
 RequiredFieldsChecker ERROR: VenicePushJob job23 must set avroKeyField, avroValueField, clusterName, inputPath, veniceStoreName
-RequiredFieldsChecker ERROR: TensorFlowJob job24 has the following required fields: taskCommand
 RequiredFieldsChecker ERROR: TensorFlowJob job24 has the following required fields: archive
 RequiredFieldsChecker WARNING: Properties properties1 does not set any confProperties, jobProperties, jvmProperties or basePropertySetName. Nothing will be built for this properties object.
 :hadoop-plugin-test:test_missingFields FAILED

--- a/hadoop-plugin-test/src/main/gradle/positive/jobs1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/jobs1.gradle
@@ -393,7 +393,6 @@ hadoop {
       numWorkers 4
       archive 'tensorflow-starter-kit.zip'
       jar 'tensorflow-on-yarn-0.0.1.jar'
-      taskCommand './tf.py'
       set workerEnv: [
         'ENV1': 'val1',
         'ENV2': 'val2'

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/RequiredFieldsChecker.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/RequiredFieldsChecker.groovy
@@ -312,7 +312,6 @@ class RequiredFieldsChecker extends BaseStaticChecker {
 
   @Override
   void visitJob(TensorFlowJob job) {
-    foundError |= validateNotEmpty(job, "taskCommand", job.taskCommand);
     foundError |= validateNotEmpty(job, "archive", job.archive);
   }
 

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/TensorFlowJob.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/TensorFlowJob.groovy
@@ -34,7 +34,6 @@ import com.linkedin.gradle.hadoopdsl.HadoopDslMethod;
  *     numWorkers 4
  *     archive 'tensorflow-starter-kit-1.4.16-SNAPSHOT-azkaban.zip'
  *     jar 'tensorflow-on-yarn-0.0.1.jar'
- *     taskCommand ''
  *     set workerEnv: [
  *       'ENV1': 'val1',
  *       'ENV2': 'val2'
@@ -54,7 +53,6 @@ class TensorFlowJob extends HadoopJavaProcessJob {
   int numWorkers;
   String archive;
   String jar;
-  String taskCommand;
   Map<String, Object> workerEnv;
 
   /**
@@ -96,7 +94,6 @@ class TensorFlowJob extends HadoopJavaProcessJob {
     cloneJob.numWorkers = numWorkers;
     cloneJob.archive = archive;
     cloneJob.jar = jar;
-    cloneJob.taskCommand = taskCommand;
     cloneJob.workerEnv.putAll(workerEnv);
     return ((TensorFlowJob)super.clone(cloneJob));
   }
@@ -233,18 +230,6 @@ class TensorFlowJob extends HadoopJavaProcessJob {
   void jar(String jar) {
     this.jar = jar;
     setJobProperty("jar", this.jar);
-  }
-
-  /**
-   * Sets the task command which will be run on each parameter server/worker.
-   * Leaving this unset will default to the Hadoop application's default value.
-   *
-   * @param taskCommand Command to run on each parameter server/worker
-   */
-  @HadoopDslMethod
-  void taskCommand(String taskCommand) {
-    this.taskCommand = taskCommand;
-    setJobProperty("task_command", this.taskCommand);
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/TensorFlowJob.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/TensorFlowJob.groovy
@@ -23,6 +23,19 @@ import com.linkedin.gradle.hadoopdsl.HadoopDslMethod;
  * In the DSL, a TensorFlowJob can be specified with:
  * <pre>
  *   tensorFlowJob('jobName') {
+ *     def taskParams = [
+ *       "--tensorboard",
+ *       "--hdfs_input_path /tmp/trainingInput",
+ *       "--hdfs_output_path /tmp/trainingOutput",
+ *       "--learning_rate 0.25",
+ *       "--lambda_l2 0.01",
+ *     ].join(' ')
+ *     set properties: [
+ *       'python_binary_path': 'Python-2.7.11/bin/python',
+ *       'python_venv': "tensorflow-starter-kit-1.4.16-SNAPSHOT-venv.zip",
+ *       'executes': 'path/to/python/script.py',
+ *       'task_params': taskParams,
+ *     ]
  *     amMemory 2048
  *     amCores 1
  *     psMemory 2048


### PR DESCRIPTION
We are removing support of taskCommand in favor of allowing users to set parts of the full command (task params, python file to execute, location of virtual environment, etc.) and having the infrastructure construct the command, so the user doesn't have to construct the full command.