### PR TITLE
Upgrade li-hadoop-plugin for Flow 2.0

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -123,6 +123,8 @@ The following were contributed by Jianling Zhong. Thanks, Jianling!
 * `Add supports for a "required parameters" check`
 
 The following were contributed by Charlie Summers. Thanks, Charlie!
+* `Upgrade li-hadoop-plugin for Flow 2.0`
+* `Refactor YamlCompiler to fit closer with AzkabanDslCompiler`
 * `Allow configurable Yaml creation for Flow 2.0`
 * `Introduce YamlCompiler, YamlWorkflow, YamlJob, and YamlProject for Flow 2.0`
 * `Add ability for Hadoop DSL to understand the TableauJob job type`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,11 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.14.9
+
+* Upgrade li-hadoop-plugin for Flow 2.0
+* Refactor YamlCompiler to fit closer with AzkabanDslCompiler
+
 0.14.8
 
 * Remove taskCommand in tensorflow dsl job

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCompilerUtils.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCompilerUtils.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.gradle.azkaban
+
+/**
+ * Helpful utils for the Azkaban Compilers.
+ */
+class AzkabanCompilerUtils {
+  /**
+   * Helper method to sort a list of properties from a Job or a Properties object into a
+   * standardized, sorted order that will make reading job and property files easy.
+   *
+   * @param propertyNames The property names for a Job or Properties object
+   * @return The property names in a standardized, sorted order
+   */
+  static List<String> sortPropertiesToBuild(Set<String> propertyNames) {
+    // First, sort the properties alphabetically.
+    List<String> propertyList = new ArrayList<String>(propertyNames);
+    Collections.sort(propertyList);
+
+    List<String> sortedKeys = new ArrayList<String>(propertyList.size());
+
+    // List the job type and dependencies first if they exist.
+    if (propertyList.remove("type")) {
+      sortedKeys.add("type");
+    }
+
+    if (propertyList.remove("dependencies")) {
+      sortedKeys.add("dependencies");
+    }
+
+    // Then add the rest of the keys to the final list of sorted keys.
+    sortedKeys.addAll(propertyList);
+    return sortedKeys;
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslCompiler.groovy
@@ -24,6 +24,7 @@ import com.linkedin.gradle.hadoopdsl.Workflow;
 import com.linkedin.gradle.hadoopdsl.job.Job;
 
 import org.gradle.api.Project;
+import static AzkabanCompilerUtils.sortPropertiesToBuild;
 
 /**
  * Hadoop DSL compiler for Azkaban.
@@ -236,33 +237,5 @@ class AzkabanDslCompiler extends BaseCompiler {
 
     // Set to read-only to remind people that they should not be editing the job files.
     file.setWritable(false);
-  }
-
-  /**
-   * Helper method to sort a list of properties from a Job or a Properties object into a
-   * standardized, sorted order that will make reading job and property files easy.
-   *
-   * @param propertyNames The property names for a Job or Properties object
-   * @return The property names in a standardized, sorted order
-   */
-  static List<String> sortPropertiesToBuild(Set<String> propertyNames) {
-    // First, sort the properties alphabetically.
-    List<String> propertyList = new ArrayList<String>(propertyNames);
-    Collections.sort(propertyList);
-
-    List<String> sortedKeys = new ArrayList<String>(propertyList.size());
-
-    // List the job type and dependencies first if they exist.
-    if (propertyList.remove("type")) {
-      sortedKeys.add("type");
-    }
-
-    if (propertyList.remove("dependencies")) {
-      sortedKeys.add("dependencies");
-    }
-
-    // Then add the rest of the keys to the final list of sorted keys.
-    sortedKeys.addAll(propertyList);
-    return sortedKeys;
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -39,16 +39,16 @@ import static com.linkedin.gradle.azkaban.AzkabanConstants.AZK_FLOW_VERSION;
  * workflows.gradle file (or equivalent). The default is .job/.properties for now.
  * TODO reallocf change default to .flow/.project in the future
  */
-class YamlCompiler extends BaseCompiler {
+class AzkabanDslYamlCompiler extends BaseCompiler {
   Yaml yamlDumper;
   String yamlProjectName;
 
   /**
-   * Constructor for the YamlCompiler.
+   * Constructor for the AzkabanDslYamlCompiler.
    *
    * @param project The Gradle project
    */
-  YamlCompiler(Project project) {
+  AzkabanDslYamlCompiler(Project project) {
     super(project);
     this.yamlDumper = setupYamlObject();
     this.yamlProjectName = project.name;
@@ -135,7 +135,7 @@ class YamlCompiler extends BaseCompiler {
   }
 
   /**
-   * Dumps the YamlProject for this YamlCompiler.
+   * Dumps the YamlProject for this AzkabanDslYamlCompiler.
    */
   void visitProject() {
     File out = new File(this.parentDirectory, "${this.yamlProjectName}.project");

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
@@ -16,7 +16,7 @@
 package com.linkedin.gradle.hadoopdsl;
 
 import com.linkedin.gradle.azkaban.AzkabanDslCompiler;
-import com.linkedin.gradle.azkaban.YamlCompiler;
+import com.linkedin.gradle.azkaban.AzkabanDslYamlCompiler;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
@@ -512,7 +512,7 @@ class HadoopDslPlugin extends BaseNamedScopeContainer implements Plugin<Project>
 
   /**
    * Based on whether or not the flag generate_yaml_output is set to true in the hadoop scope
-   * (i.e. within the hadoop { } closure), select between YamlCompiler and AzkabanDslCompiler.
+   * (i.e. within the hadoop { } closure), select between AzkabanDslYamlCompiler and AzkabanDslCompiler.
    *
    * Default is AzkabanDslCompiler for now.
    *
@@ -524,6 +524,6 @@ class HadoopDslPlugin extends BaseNamedScopeContainer implements Plugin<Project>
    */
   HadoopDslCompiler selectCompilerType(Project project) {
     return scope.lookup(GENERATE_YAML_OUTPUT_FLAG_LOCATION) ?
-            new YamlCompiler(project) : new AzkabanDslCompiler(project);
+            new AzkabanDslYamlCompiler(project) : new AzkabanDslCompiler(project);
   }
 }

--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class YamlCompilerTest {
+class AzkabanDslYamlCompilerTest {
   NamedScope mockHadoopScope = mock(NamedScope.class);
   NamedScope mockRootScope = mock(NamedScope.class);
   Job mockJob = mock(Job.class);
@@ -40,7 +40,7 @@ class YamlCompilerTest {
   Workflow mockWorkflow = mock(Workflow.class);
   NamedScope mockSubflowScope = mock(NamedScope.class);
   Workflow mockSubflow = mock(Workflow.class);
-  YamlCompiler yamlCompiler;
+  AzkabanDslYamlCompiler yamlCompiler;
 
   @Before
   public void setup() {
@@ -71,7 +71,7 @@ class YamlCompilerTest {
 
     Project mockProject = mock(Project.class);
     when(mockProject.name).thenReturn("test");
-    yamlCompiler = new YamlCompiler(mockProject);
+    yamlCompiler = new AzkabanDslYamlCompiler(mockProject);
     yamlCompiler.parentScope = mockHadoopScope;
   }
 

--- a/li-hadoop-plugin/build.gradle
+++ b/li-hadoop-plugin/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   provided project(":hadoop-plugin")
 
   testCompile 'junit:junit:4.12'
+  testCompile 'org.mockito:mockito-core:2.10.0'
 }
 
 task sourceJar(type: Jar) {

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanCompilerUtils.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanCompilerUtils.groovy
@@ -107,6 +107,7 @@ class LiAzkabanCompilerUtils extends AzkabanCompilerUtils {
    * Extracts the information to write from the bangbang template.
    *
    * @param job The job for which information should be extracted
+   * @param parentScope The parent scope of the job being extracted
    * @return The text for the gradle file
    */
   static String getBangBangGradleText(LiBangBangJob job, NamedScope parentScope) {

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanCompilerUtils.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanCompilerUtils.groovy
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2015 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.gradle.liazkaban
+
+import com.linkedin.gradle.azkaban.AzkabanCompilerUtils;
+import com.linkedin.gradle.hadoopdsl.NamedScope;
+import com.linkedin.gradle.liazkaban.LiAzkabanJavaProperties;
+import com.linkedin.gradle.libangbang.LiHadoopShellCommand;
+import com.linkedin.gradle.libangbang.LiHadoopShellCommandFactory;
+import com.linkedin.gradle.lihadoopdsl.lijob.LiBangBangJob;
+import groovy.text.GStringTemplateEngine;
+import groovy.text.Template
+import org.gradle.api.Project;
+
+/**
+ * Helpful utils for the LiAzkaban Compilers.
+ */
+class LiAzkabanCompilerUtils extends AzkabanCompilerUtils {
+
+  private static final String BANGBANG_TEMPLATE = "LiBangBangJob.template";
+  private static final String PIG_JAVA_OPTS = "env.PIG_JAVA_OPTS";
+  private static final LiHadoopShellCommandFactory bangBangCommandFactory =
+          new LiHadoopShellCommandFactory();
+
+  /**
+   * This file duplicates functionality from the superclass. We have to remove other properties
+   * from the job file apart from the command and type.
+   *
+   * @param job The LiPigBangBangJob job to build
+   * @param allProperties The original map of properties from the job
+   * @return List The filtered list of keys that need to be looked up in allProperties to get the
+   *              resulting BangBang properties.
+   */
+  static List<String> addBangBangProperties(Map<String, String> allProperties) {
+    Map<String,String> azkabanOptions = new HashMap<String,String>();
+    azkabanOptions.put(LiAzkabanJavaProperties.AZKABAN_LINK_WORKFLOW_URL, "\${${LiAzkabanJavaProperties.AZKABAN_LINK_WORKFLOW_URL}}");
+    azkabanOptions.put(LiAzkabanJavaProperties.AZKABAN_LINK_ATTEMPT_URL, "\${${LiAzkabanJavaProperties.AZKABAN_LINK_ATTEMPT_URL}}");
+    azkabanOptions.put(LiAzkabanJavaProperties.AZKABAN_LINK_JOB_URL,"\${${LiAzkabanJavaProperties.AZKABAN_LINK_JOB_URL}}");
+    azkabanOptions.put(LiAzkabanJavaProperties.AZKABAN_LINK_EXECUTION_URL, "\${${LiAzkabanJavaProperties.AZKABAN_LINK_EXECUTION_URL}}");
+    azkabanOptions.put(LiAzkabanJavaProperties.AZKABAN_JOB_INNODES,"\${${LiAzkabanJavaProperties.AZKABAN_JOB_INNODES}}");
+    azkabanOptions.put(LiAzkabanJavaProperties.AZKABAN_JOB_OUTNODES,"\${${LiAzkabanJavaProperties.AZKABAN_JOB_OUTNODES}}");
+
+    // Create JVM string of the form -Dkey1=value1 -Dkey2=value2
+    StringBuffer azkabanOpts = new StringBuffer();
+    azkabanOptions.each { key, value -> azkabanOpts.append("-D${key}=${value} "); }
+    String azkabanJvmString = azkabanOpts.toString();
+
+    // Add the Azkaban JVM String to PIG_JAVA_OPTS to add them to job conf.
+    if (allProperties.hasProperty(PIG_JAVA_OPTS)) {
+      allProperties.put(PIG_JAVA_OPTS, allProperties.get(PIG_JAVA_OPTS) + " " + azkabanJvmString);
+    } else {
+      allProperties.put(PIG_JAVA_OPTS, azkabanJvmString);
+    }
+
+    // since it is a hadoopShell job type, only some of the properties are relevant.
+    List<String> sortedKeys = sortPropertiesToBuild(allProperties.keySet());
+    List<String> filteredKeys = new ArrayList<String>();
+    Set<String> irrelevantProperties = ['pig.script','pig.home',/param.*/,'use.user.pig.jar',/hadoop-inject.*/];
+
+    for (String key: sortedKeys) {
+      boolean isRelevant = true;
+      for (String property: irrelevantProperties) {
+        if (key.matches(property)) {
+          isRelevant = false;
+          break;
+        }
+      }
+      if (isRelevant) {
+        filteredKeys.add(key);
+      }
+    }
+
+    return filteredKeys;
+  }
+
+  /**
+   * Takes a LiBangBangJob and writes the Gradle file for bangbang.
+   *
+   * @param job The LiBangBangJob Job to build
+   */
+  static void writeGradleForBangBangJob(LiBangBangJob job, Project project, NamedScope parentScope,
+          String parentDirectory) {
+    String fileName = job.buildFileName(parentScope);
+    File file = new File(parentDirectory, "${fileName}.gradle");
+    if (job.isOverwritten()) {
+      file.write(getBangBangGradleText(job, parentScope));
+      project.logger.lifecycle("Writing the ${fileName}.gradle to ${file.getAbsolutePath()}");
+    }
+  }
+
+  /**
+   * Extracts the information to write from the bangbang template.
+   *
+   * @param job The job for which information should be extracted
+   * @return The text for the gradle file
+   */
+  static String getBangBangGradleText(LiBangBangJob job, NamedScope parentScope) {
+    LiHadoopShellCommand command = bangBangCommandFactory.getCommand(job, job.buildProperties(parentScope));
+    URL templateURL = Thread.currentThread().getContextClassLoader().getResource(BANGBANG_TEMPLATE);
+
+    // Create bindings for the template
+    Map<String, Object> bindings = new HashMap<String, Object>();
+    bindings.put("dependency", job.getDependency());
+    bindings.put("executable", command.getExecutable());
+    bindings.put("argList", command.getArguments());
+    bindings.put("environmentMap", command.getEnvironment());
+
+    // Get text from the template
+    GStringTemplateEngine templateEngine = new GStringTemplateEngine();
+    Template template = templateEngine.createTemplate(templateURL.text);
+    String templateText = template.make(bindings).toString();
+    return templateText;
+  }
+}

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanCompilerUtils.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanCompilerUtils.groovy
@@ -39,7 +39,6 @@ class LiAzkabanCompilerUtils extends AzkabanCompilerUtils {
    * This file duplicates functionality from the superclass. We have to remove other properties
    * from the job file apart from the command and type.
    *
-   * @param job The LiPigBangBangJob job to build
    * @param allProperties The original map of properties from the job
    * @return List The filtered list of keys that need to be looked up in allProperties to get the
    *              resulting BangBang properties.
@@ -90,6 +89,9 @@ class LiAzkabanCompilerUtils extends AzkabanCompilerUtils {
    * Takes a LiBangBangJob and writes the Gradle file for bangbang.
    *
    * @param job The LiBangBangJob Job to build
+   * @param project The Gradle project
+   * @param parentScope The parent scope of the LiBangBangJob
+   * @param parentDirectory The string referring to the parent directory to write the gradle file to
    */
   static void writeGradleForBangBangJob(LiBangBangJob job, Project project, NamedScope parentScope,
           String parentDirectory) {

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanDslYamlCompiler.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanDslYamlCompiler.groovy
@@ -15,7 +15,7 @@
  */
 package com.linkedin.gradle.liazkaban
 
-import com.linkedin.gradle.azkaban.YamlCompiler;
+import com.linkedin.gradle.azkaban.AzkabanDslYamlCompiler;
 import com.linkedin.gradle.lihadoopdsl.lijob.LiPigBangBangJob;
 import org.gradle.api.Project
 
@@ -26,14 +26,14 @@ import static com.linkedin.gradle.liazkaban.LiAzkabanCompilerUtils.writeGradleFo
  * Simple class that wraps the YamlCompiler to specify LiYamlWorkflows instead of YamlWorkflows to
  * handle LI specific behavior.
  */
-class LiYamlCompiler extends YamlCompiler {
+class LiAzkabanDslYamlCompiler extends AzkabanDslYamlCompiler {
 
   /**
    * Constructor for the YamlCompiler.
    *
    * @param project The Gradle project
    */
-  LiYamlCompiler(Project project) {
+  LiAzkabanDslYamlCompiler(Project project) {
     super(project);
   }
 
@@ -50,15 +50,15 @@ class LiYamlCompiler extends YamlCompiler {
 
     // Add job name
     yamlizedJob["name"] = job.name;
-    // Add job dependencies if there are any
-    if (!job.dependencyNames.isEmpty()) {
-      yamlizedJob["dependsOn"] = job.dependencyNames.toList();
-    }
     // Add job configs if there are any
     Map<String, String> filteredConfig = [:];
     Map<String, String> config = job.buildProperties(this.parentScope);
     // Add job type after test to pick up LiBangBangJob type switch from pig -> hadoopShell
     yamlizedJob["type"] = config["type"];
+    // Add job dependencies if there are any
+    if (!job.dependencyNames.isEmpty()) {
+      yamlizedJob["dependsOn"] = job.dependencyNames.toList();
+    }
     // Remove type and dependencies from config because they're represented elsewhere
     config.remove("type");
     config.remove("dependencies");

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanDslYamlCompiler.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanDslYamlCompiler.groovy
@@ -42,7 +42,6 @@ class LiAzkabanDslYamlCompiler extends AzkabanDslYamlCompiler {
    * This includes generate the required BangBang gradle file.
    *
    * @param job LiPigBangBangJob whose config will be modified
-   * @param parentScope Parent scope of the job
    * @return Filtered string map of properties to be output in Yaml
    */
   Map<String,String> yamlizeJob(LiPigBangBangJob job) {

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanPlugin.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanPlugin.groovy
@@ -15,7 +15,7 @@
  */
 package com.linkedin.gradle.liazkaban;
 
-import com.linkedin.gradle.azkaban.AzkabanDslCompiler;
+import com.linkedin.gradle.hadoopdsl.HadoopDslCompiler;
 import com.linkedin.gradle.azkaban.AzkabanFlowStatusTask;
 import com.linkedin.gradle.azkaban.AzkabanHelper;
 import com.linkedin.gradle.azkaban.AzkabanPlugin;
@@ -71,8 +71,8 @@ class LiAzkabanPlugin extends AzkabanPlugin {
    * @return The AzkabanDslCompiler
    */
   @Override
-  AzkabanDslCompiler makeCompiler(Project project) {
-    return new LiAzkabanDslCompiler(project);
+  HadoopDslCompiler makeCompiler(Project project) {
+    return project.extensions.hadoopDslPlugin.selectCompilerType(project);
   }
 
   /**

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiYamlCompiler.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiYamlCompiler.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.gradle.liazkaban
+
+import com.linkedin.gradle.azkaban.YamlCompiler;
+import com.linkedin.gradle.lihadoopdsl.lijob.LiPigBangBangJob;
+import org.gradle.api.Project
+
+import static com.linkedin.gradle.liazkaban.LiAzkabanCompilerUtils.addBangBangProperties
+import static com.linkedin.gradle.liazkaban.LiAzkabanCompilerUtils.writeGradleForBangBangJob;
+
+/**
+ * Simple class that wraps the YamlCompiler to specify LiYamlWorkflows instead of YamlWorkflows to
+ * handle LI specific behavior.
+ */
+class LiYamlCompiler extends YamlCompiler {
+
+  /**
+   * Constructor for the YamlCompiler.
+   *
+   * @param project The Gradle project
+   */
+  LiYamlCompiler(Project project) {
+    super(project);
+  }
+
+  /**
+   * Handle LiPigBangBangJob as a special case to introduce LI specific functionality.
+   * This includes generate the required BangBang gradle file.
+   *
+   * @param job LiPigBangBangJob whose config will be modified
+   * @param parentScope Parent scope of the job
+   * @return Filtered string map of properties to be output in Yaml
+   */
+  Map<String,String> yamlizeJob(LiPigBangBangJob job) {
+    Map yamlizedJob = [:];
+
+    // Add job name
+    yamlizedJob["name"] = job.name;
+    // Add job type
+    yamlizedJob["type"] = job.jobProperties["type"];
+    // Add job dependencies if there are any
+    if (!job.dependencyNames.isEmpty()) {
+      yamlizedJob["dependsOn"] = job.dependencyNames.toList();
+    }
+    // Add job configs if there are any
+    Map<String, String> filteredConfig = [:];
+    Map<String, String> config = job.buildProperties(this.parentScope);
+    // Remove type and dependencies from config because they're represented elsewhere
+    config.remove("type");
+    config.remove("dependencies");
+    writeGradleForBangBangJob(job, this.project, this.parentScope, this.parentDirectory);
+    List<String> filteredKeys = addBangBangProperties(config);
+    filteredKeys.each { key ->
+      filteredConfig[key] = config[key];
+    }
+    if (!filteredConfig.isEmpty()) {
+      yamlizedJob["config"] = filteredConfig;
+    }
+
+    return yamlizedJob;
+  }
+
+}

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiYamlCompiler.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiYamlCompiler.groovy
@@ -50,8 +50,6 @@ class LiYamlCompiler extends YamlCompiler {
 
     // Add job name
     yamlizedJob["name"] = job.name;
-    // Add job type
-    yamlizedJob["type"] = job.jobProperties["type"];
     // Add job dependencies if there are any
     if (!job.dependencyNames.isEmpty()) {
       yamlizedJob["dependsOn"] = job.dependencyNames.toList();
@@ -59,6 +57,8 @@ class LiYamlCompiler extends YamlCompiler {
     // Add job configs if there are any
     Map<String, String> filteredConfig = [:];
     Map<String, String> config = job.buildProperties(this.parentScope);
+    // Add job type after test to pick up LiBangBangJob type switch from pig -> hadoopShell
+    yamlizedJob["type"] = config["type"];
     // Remove type and dependencies from config because they're represented elsewhere
     config.remove("type");
     config.remove("dependencies");

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/lihadoopdsl/LiHadoopDslPlugin.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/lihadoopdsl/LiHadoopDslPlugin.groovy
@@ -15,9 +15,12 @@
  */
 package com.linkedin.gradle.lihadoopdsl;
 
+import com.linkedin.gradle.hadoopdsl.HadoopDslCompiler;
 import com.linkedin.gradle.hadoopdsl.HadoopDslFactory;
 import com.linkedin.gradle.hadoopdsl.HadoopDslMethod;
 import com.linkedin.gradle.hadoopdsl.HadoopDslPlugin;
+import com.linkedin.gradle.liazkaban.LiAzkabanDslCompiler;
+import com.linkedin.gradle.liazkaban.LiYamlCompiler;
 import com.linkedin.gradle.lihadoopdsl.lijob.AutoTunePigLiJob;
 import com.linkedin.gradle.lihadoopdsl.lijob.LiPigBangBangJob;
 import com.linkedin.gradle.lihadoopdsl.lijob.PigLiJob;
@@ -27,6 +30,9 @@ import org.gradle.api.Project;
  * LinkedIn-specific customizations to the Hadoop DSL Plugin.
  */
 class LiHadoopDslPlugin extends HadoopDslPlugin implements LiNamedScopeContainer {
+
+  static final String GENERATE_YAML_OUTPUT_FLAG_LOCATION = ".hadoop.generate_yaml_output";
+
   /**
    * Applies the LinkedIn-specific Hadoop DSL Plugin.
    *
@@ -97,5 +103,22 @@ class LiHadoopDslPlugin extends HadoopDslPlugin implements LiNamedScopeContainer
   AutoTunePigLiJob autoTunePigLiJob(String name, @DelegatesTo(AutoTunePigLiJob) Closure configure){
     LiHadoopDslFactory liFactory = (LiHadoopDslFactory)factory;
     return ((AutoTunePigLiJob)configureJob(liFactory.makeAutoTunePigLiJob(name), configure));
+  }
+
+  /**
+   * Based on whether or not the flag generate_yaml_output is set to true in the hadoop scope
+   * (i.e. within the hadoop { } closure), select between LiYamlCompiler and LiAzkabanDslCompiler.
+   *
+   * Default is LiAzkabanDslCompiler for now.
+   *
+   * Flag is called 'generate_yaml_output' because underscores are not allowed in the names of
+   * other Hadoop objects, so it is highly unlikely for there to be unintentional collisions.
+   *
+   * @param project The Gradle project
+   * @return The User-configured Compiler, default is LiAzkabanDslCompiler
+   */
+  HadoopDslCompiler selectCompilerType(Project project) {
+    return scope.lookup(GENERATE_YAML_OUTPUT_FLAG_LOCATION) ?
+            new LiYamlCompiler(project) : new LiAzkabanDslCompiler(project);
   }
 }

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/lihadoopdsl/LiHadoopDslPlugin.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/lihadoopdsl/LiHadoopDslPlugin.groovy
@@ -19,8 +19,8 @@ import com.linkedin.gradle.hadoopdsl.HadoopDslCompiler;
 import com.linkedin.gradle.hadoopdsl.HadoopDslFactory;
 import com.linkedin.gradle.hadoopdsl.HadoopDslMethod;
 import com.linkedin.gradle.hadoopdsl.HadoopDslPlugin;
-import com.linkedin.gradle.liazkaban.LiAzkabanDslCompiler;
-import com.linkedin.gradle.liazkaban.LiYamlCompiler;
+import com.linkedin.gradle.liazkaban.LiAzkabanDslCompiler
+import com.linkedin.gradle.liazkaban.LiAzkabanDslYamlCompiler;
 import com.linkedin.gradle.lihadoopdsl.lijob.AutoTunePigLiJob;
 import com.linkedin.gradle.lihadoopdsl.lijob.LiPigBangBangJob;
 import com.linkedin.gradle.lihadoopdsl.lijob.PigLiJob;
@@ -107,7 +107,7 @@ class LiHadoopDslPlugin extends HadoopDslPlugin implements LiNamedScopeContainer
 
   /**
    * Based on whether or not the flag generate_yaml_output is set to true in the hadoop scope
-   * (i.e. within the hadoop { } closure), select between LiYamlCompiler and LiAzkabanDslCompiler.
+   * (i.e. within the hadoop { } closure), select between LiAzkabanDslYamlCompiler and LiAzkabanDslCompiler.
    *
    * Default is LiAzkabanDslCompiler for now.
    *
@@ -119,6 +119,6 @@ class LiHadoopDslPlugin extends HadoopDslPlugin implements LiNamedScopeContainer
    */
   HadoopDslCompiler selectCompilerType(Project project) {
     return scope.lookup(GENERATE_YAML_OUTPUT_FLAG_LOCATION) ?
-            new LiYamlCompiler(project) : new LiAzkabanDslCompiler(project);
+            new LiAzkabanDslYamlCompiler(project) : new LiAzkabanDslCompiler(project);
   }
 }

--- a/li-hadoop-plugin/src/test/groovy/com/linkedin/gradle/liazkaban/yaml/YamlBangBangJobTest.groovy
+++ b/li-hadoop-plugin/src/test/groovy/com/linkedin/gradle/liazkaban/yaml/YamlBangBangJobTest.groovy
@@ -16,7 +16,7 @@
 package com.linkedin.gradle.liazkaban.yaml;
 
 import com.linkedin.gradle.hadoopdsl.NamedScope
-import com.linkedin.gradle.liazkaban.LiYamlCompiler;
+import com.linkedin.gradle.liazkaban.LiAzkabanDslYamlCompiler;
 import com.linkedin.gradle.lihadoopdsl.lijob.LiPigBangBangJob
 import org.gradle.api.Project;
 import org.junit.Test;
@@ -30,7 +30,7 @@ class YamlBangBangJobTest {
   @Test
   public void TestYamlBangBangJob() {
     Project mockProject = mock(Project.class);
-    LiYamlCompiler liYamlCompiler = new LiYamlCompiler(mockProject);
+    LiAzkabanDslYamlCompiler liYamlCompiler = new LiAzkabanDslYamlCompiler(mockProject);
     liYamlCompiler.parentDirectory = "build/tmp"
     NamedScope mockNamedScope = mock(NamedScope.class);
     liYamlCompiler.parentScope = mockNamedScope;

--- a/li-hadoop-plugin/src/test/groovy/com/linkedin/gradle/liazkaban/yaml/YamlBangBangJobTest.groovy
+++ b/li-hadoop-plugin/src/test/groovy/com/linkedin/gradle/liazkaban/yaml/YamlBangBangJobTest.groovy
@@ -36,13 +36,13 @@ class YamlBangBangJobTest {
     liYamlCompiler.parentScope = mockNamedScope;
     LiPigBangBangJob mockLiBangBangJob = mock(LiPigBangBangJob.class);
     when(mockLiBangBangJob.name).thenReturn("test");
-    when(mockLiBangBangJob.jobProperties).thenReturn(["type": "pig"]);
+    when(mockLiBangBangJob.jobProperties).thenReturn(["type": "hadoopShell"]);
     when(mockLiBangBangJob.dependencyNames).thenReturn([].toSet());
-    when(mockLiBangBangJob.buildProperties(mockNamedScope)).thenReturn([:]);
+    when(mockLiBangBangJob.buildProperties(mockNamedScope)).thenReturn(["type": "hadoopShell"]);
 
     Map yamlizedJob = liYamlCompiler.yamlizeJob(mockLiBangBangJob);
     assertEquals("test", yamlizedJob["name"]);
-    assertEquals("pig", yamlizedJob["type"]);
+    assertEquals("hadoopShell", yamlizedJob["type"]);
     assertFalse(yamlizedJob.containsKey("dependsOn"));
     assertEquals("-Dazkaban.link.workflow.url=\${azkaban.link.workflow.url} " +
             "-Dazkaban.link.execution.url=\${azkaban.link.execution.url} " +

--- a/li-hadoop-plugin/src/test/groovy/com/linkedin/gradle/liazkaban/yaml/YamlBangBangJobTest.groovy
+++ b/li-hadoop-plugin/src/test/groovy/com/linkedin/gradle/liazkaban/yaml/YamlBangBangJobTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.gradle.liazkaban.yaml;
+
+import com.linkedin.gradle.hadoopdsl.NamedScope
+import com.linkedin.gradle.liazkaban.LiYamlCompiler;
+import com.linkedin.gradle.lihadoopdsl.lijob.LiPigBangBangJob
+import org.gradle.api.Project;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class YamlBangBangJobTest {
+  @Test
+  public void TestYamlBangBangJob() {
+    Project mockProject = mock(Project.class);
+    LiYamlCompiler liYamlCompiler = new LiYamlCompiler(mockProject);
+    liYamlCompiler.parentDirectory = "build/tmp"
+    NamedScope mockNamedScope = mock(NamedScope.class);
+    liYamlCompiler.parentScope = mockNamedScope;
+    LiPigBangBangJob mockLiBangBangJob = mock(LiPigBangBangJob.class);
+    when(mockLiBangBangJob.name).thenReturn("test");
+    when(mockLiBangBangJob.jobProperties).thenReturn(["type": "pig"]);
+    when(mockLiBangBangJob.dependencyNames).thenReturn([].toSet());
+    when(mockLiBangBangJob.buildProperties(mockNamedScope)).thenReturn([:]);
+
+    Map yamlizedJob = liYamlCompiler.yamlizeJob(mockLiBangBangJob);
+    assertEquals("test", yamlizedJob["name"]);
+    assertEquals("pig", yamlizedJob["type"]);
+    assertFalse(yamlizedJob.containsKey("dependsOn"));
+    assertEquals("-Dazkaban.link.workflow.url=\${azkaban.link.workflow.url} " +
+            "-Dazkaban.link.execution.url=\${azkaban.link.execution.url} " +
+            "-Dazkaban.job.outnodes=\${azkaban.job.outnodes} " +
+            "-Dazkaban.link.job.url=\${azkaban.link.job.url} " +
+            "-Dazkaban.link.attempt.url=\${azkaban.link.attempt.url} " +
+            "-Dazkaban.job.innodes=\${azkaban.job.innodes} ",
+            yamlizedJob["config"]["env.PIG_JAVA_OPTS"]);
+  }
+}


### PR DESCRIPTION
Introduces LiYamlCompiler. The sole difference between this compiler and the YamlCompiler is how it handles the LiPigBangBang job. This mirrors how the AzkabanDslCompiler and the LiAzkabanDslCompiler are related.

Moves common functions accessed in the AzkabanDslCompiler + YamlCompiler and their Li equivalents into AzkabanCompilerUtils and LiAzkabanCompilerUtils classes.

I also added a unit test to make sure the LiYamlCompiler handles LiPigBangBang jobs correctly.

Other than that this PR adds a little bit of wiring in LiAzkabanPlugin and LiHadoopDslPlugin similar to AzkabanPlugin and HadoopDslPlugin to allow users to toggle between .job/.properties and .flow/.project creation.