### PR TITLE
DSL Trigger Implementation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -123,6 +123,7 @@ The following were contributed by Jianling Zhong. Thanks, Jianling!
 * `Add supports for a "required parameters" check`
 
 The following were contributed by Charlie Summers. Thanks, Charlie!
+* `DSL Trigger Implementation`
 * `Upgrade li-hadoop-plugin for Flow 2.0`
 * `Refactor YamlCompiler to fit closer with AzkabanDslCompiler`
 * `Allow configurable Yaml creation for Flow 2.0`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,10 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.14.10
+
+* DSL Trigger Implementation
+
 0.14.9
 
 * Upgrade li-hadoop-plugin for Flow 2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.14.9
+version=0.14.10

--- a/hadoop-plugin-test/expectedJobs/triggerFlow/hadoop-plugin-test.project
+++ b/hadoop-plugin-test/expectedJobs/triggerFlow/hadoop-plugin-test.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/hadoop-plugin-test/expectedJobs/triggerFlow/triggerFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/triggerFlow/triggerFlow.flow
@@ -11,13 +11,14 @@ trigger:
       delay: 1
       window: 1
       unit: daily
-      ignoreLocation: true
+      ignoreLocation: 'true'
   - name: other-name
     type: dali-dataset
     params:
       view: another dataset
       delay: 1
       window: 7
+      unit: hourly
 config:
   flow-level-parameter: value
 nodes:

--- a/hadoop-plugin-test/expectedJobs/triggerFlow/triggerFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/triggerFlow/triggerFlow.flow
@@ -1,0 +1,41 @@
+trigger:
+  maxWaitMins: 5
+  schedule:
+    type: cron
+    value: 0 0 1 ? * *
+  triggerDependencies:
+  - name: search-impression
+    type: dali-dataset
+    params:
+      view: search_mp_versioned.search_impression_event_0_0_47
+      delay: 1
+      window: 1
+      unit: daily
+      ignoreLocation: true
+  - name: other-name
+    type: dali-dataset
+    params:
+      view: another dataset
+      delay: 1
+      window: 7
+config:
+  flow-level-parameter: value
+nodes:
+- name: triggerFlow
+  type: noop
+  dependsOn:
+  - shellPwd
+  - shellEcho
+  - shellBash
+- name: shellPwd
+  type: command
+  config:
+    command: pwd
+- name: shellEcho
+  type: command
+  config:
+    command: echo "This is an echoed text."
+- name: shellBash
+  type: command
+  config:
+    command: bash ./sample_script.sh

--- a/hadoop-plugin-test/expectedJobs/triggerFlow/triggerFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/triggerFlow/triggerFlow.flow
@@ -5,15 +5,15 @@ trigger:
     value: 0 0 1 ? * *
   triggerDependencies:
   - name: search-impression
-    type: dali-dataset
+    type: dali
     params:
       view: search_mp_versioned.search_impression_event_0_0_47
       delay: 1
       window: 1
       unit: daily
-      ignoreLocation: 'true'
+      ignoreLocation: true
   - name: other-name
-    type: dali-dataset
+    type: dali
     params:
       view: another dataset
       delay: 1

--- a/hadoop-plugin-test/expectedOutput/negative/triggerCheck.out
+++ b/hadoop-plugin-test/expectedOutput/negative/triggerCheck.out
@@ -1,0 +1,27 @@
+:hadoop-plugin-test:test_triggerCheck
+Running test for the file negative/triggerCheck.gradle
+TriggerChecker ERROR: Workflow triggerFail1 contains more than 1 trigger.
+TriggerChecker ERROR: Trigger trigger1 in Workflow triggerFail1 must define 'maxWaitMins' and it must be greater than 0.
+TriggerChecker ERROR: Trigger trigger1 in Workflow triggerFail1 does not contain a schedule.
+TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a view.
+TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a window.
+TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a delay.
+TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a unit.
+TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must have a window greater than 0.
+TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must have a nonnegative delay.
+TriggerChecker ERROR: 'unit' value in DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 can only be set to 'daily' or 'hourly'.
+TriggerChecker ERROR: Trigger trigger2 in Workflow triggerFail1 must define 'maxWaitMins' and it must be greater than 0.
+TriggerChecker ERROR: Trigger trigger2 in Workflow triggerFail1 contains more than one schedule.
+TriggerChecker ERROR: Schedule schedule1 in Trigger trigger2 in Workflow triggerFail1 must define 'value'.
+TriggerChecker ERROR: Schedule schedule2 in Trigger trigger2 in Workflow triggerFail1 must define 'value' as a valid cron expression.
+TriggerChecker WARN: Trigger trigger3 in Workflow triggerFail2 defines 'maxWaitMins' to be greater than 10 days. Azkaban will automatically reduce to 10 days.
+TriggerChecker ERROR: Schedule schedule1 in Trigger trigger3 in Workflow triggerFail2 must define interval of flow trigger to be larger than 1 minute.
+TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a window greater than 0.
+TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
+TriggerChecker ERROR: 'unit' value in DaliDatasetDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 can only be set to 'daily' or 'hourly'.
+TriggerChecker ERROR: 'ignoreLocation' value in DaliDatasetDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 can only be set to 'true' or 'false'.
+TriggerChecker ERROR: Trigger trigger3 in Workflow triggerFail2 contains dependencies with the same name.
+TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
+TriggerChecker ERROR: Trigger trigger3 in Workflow triggerFail2 contains duplicate dependencies (same type and parameters).
+TriggerChecker ERROR: DaliDatasetDependency dali-data-dep2 in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
+:hadoop-plugin-test:test_triggerCheck FAILED

--- a/hadoop-plugin-test/expectedOutput/negative/triggerCheck.out
+++ b/hadoop-plugin-test/expectedOutput/negative/triggerCheck.out
@@ -12,15 +12,13 @@ TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger1 in Workfl
 TriggerChecker ERROR: 'unit' value in DaliDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 can only be set to 'daily' or 'hourly'.
 TriggerChecker ERROR: Trigger trigger2 in Workflow triggerFail1 must define 'maxWaitMins' and it must be greater than 0.
 TriggerChecker ERROR: Trigger trigger2 in Workflow triggerFail1 contains more than one schedule.
-TriggerChecker ERROR: Schedule schedule1 in Trigger trigger2 in Workflow triggerFail1 must define 'value'.
-TriggerChecker ERROR: Schedule schedule2 in Trigger trigger2 in Workflow triggerFail1 must define 'value' as a valid cron expression.
+TriggerChecker ERROR: Schedule in Trigger trigger2 in Workflow triggerFail1 must define 'value'.
+TriggerChecker ERROR: Schedule in Trigger trigger2 in Workflow triggerFail1 must define 'value' as a valid cron expression.
 TriggerChecker WARN: Trigger trigger3 in Workflow triggerFail2 defines 'maxWaitMins' to be greater than 10 days. Azkaban will automatically reduce to 10 days.
-TriggerChecker ERROR: Schedule schedule1 in Trigger trigger3 in Workflow triggerFail2 must define interval of flow trigger to be larger than 1 minute.
+TriggerChecker ERROR: Schedule in Trigger trigger3 in Workflow triggerFail2 must define interval of flow trigger to be larger than 1 minute.
 TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a window greater than 0.
 TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
 TriggerChecker ERROR: 'unit' value in DaliDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 can only be set to 'daily' or 'hourly'.
 TriggerChecker ERROR: Trigger trigger3 in Workflow triggerFail2 contains dependencies with the same name.
-TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
 TriggerChecker ERROR: Trigger trigger3 in Workflow triggerFail2 contains duplicate dependencies (same type and parameters).
-TriggerChecker ERROR: DaliDependency dali-data-dep2 in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
 :hadoop-plugin-test:test_triggerCheck FAILED

--- a/hadoop-plugin-test/expectedOutput/negative/triggerCheck.out
+++ b/hadoop-plugin-test/expectedOutput/negative/triggerCheck.out
@@ -3,25 +3,24 @@ Running test for the file negative/triggerCheck.gradle
 TriggerChecker ERROR: Workflow triggerFail1 contains more than 1 trigger.
 TriggerChecker ERROR: Trigger trigger1 in Workflow triggerFail1 must define 'maxWaitMins' and it must be greater than 0.
 TriggerChecker ERROR: Trigger trigger1 in Workflow triggerFail1 does not contain a schedule.
-TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a view.
-TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a window.
-TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a delay.
-TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a unit.
-TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must have a window greater than 0.
-TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must have a nonnegative delay.
-TriggerChecker ERROR: 'unit' value in DaliDatasetDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 can only be set to 'daily' or 'hourly'.
+TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a view.
+TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a window.
+TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a delay.
+TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must define a unit.
+TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must have a window greater than 0.
+TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 must have a nonnegative delay.
+TriggerChecker ERROR: 'unit' value in DaliDependency dali-data-dep in Trigger trigger1 in Workflow triggerFail1 can only be set to 'daily' or 'hourly'.
 TriggerChecker ERROR: Trigger trigger2 in Workflow triggerFail1 must define 'maxWaitMins' and it must be greater than 0.
 TriggerChecker ERROR: Trigger trigger2 in Workflow triggerFail1 contains more than one schedule.
 TriggerChecker ERROR: Schedule schedule1 in Trigger trigger2 in Workflow triggerFail1 must define 'value'.
 TriggerChecker ERROR: Schedule schedule2 in Trigger trigger2 in Workflow triggerFail1 must define 'value' as a valid cron expression.
 TriggerChecker WARN: Trigger trigger3 in Workflow triggerFail2 defines 'maxWaitMins' to be greater than 10 days. Azkaban will automatically reduce to 10 days.
 TriggerChecker ERROR: Schedule schedule1 in Trigger trigger3 in Workflow triggerFail2 must define interval of flow trigger to be larger than 1 minute.
-TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a window greater than 0.
-TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
-TriggerChecker ERROR: 'unit' value in DaliDatasetDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 can only be set to 'daily' or 'hourly'.
-TriggerChecker ERROR: 'ignoreLocation' value in DaliDatasetDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 can only be set to 'true' or 'false'.
+TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a window greater than 0.
+TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
+TriggerChecker ERROR: 'unit' value in DaliDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 can only be set to 'daily' or 'hourly'.
 TriggerChecker ERROR: Trigger trigger3 in Workflow triggerFail2 contains dependencies with the same name.
-TriggerChecker ERROR: DaliDatasetDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
+TriggerChecker ERROR: DaliDependency dali-data-dep in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
 TriggerChecker ERROR: Trigger trigger3 in Workflow triggerFail2 contains duplicate dependencies (same type and parameters).
-TriggerChecker ERROR: DaliDatasetDependency dali-data-dep2 in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
+TriggerChecker ERROR: DaliDependency dali-data-dep2 in Trigger trigger3 in Workflow triggerFail2 must have a nonnegative delay.
 :hadoop-plugin-test:test_triggerCheck FAILED

--- a/hadoop-plugin-test/expectedOutput/positive/triggerFlow.out
+++ b/hadoop-plugin-test/expectedOutput/positive/triggerFlow.out
@@ -1,0 +1,4 @@
+:hadoop-plugin-test:test_triggerFlow
+Running test for the file positive/triggerFlow.gradle
+Hadoop DSL static checker PASSED
+

--- a/hadoop-plugin-test/src/main/gradle/negative/triggerCheck.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/triggerCheck.gradle
@@ -34,10 +34,10 @@ hadoop {
 
     trigger('trigger2') { // two defined triggers throws an ERROR
       maxWaitMins 0 // maxWaitMins less than 1 throws an ERROR
-      schedule('schedule1') {
+      schedule {
         // no schedule value throws an ERROR
       }
-      schedule('schedule2') { // two schedules throws an ERROR
+      schedule { // two schedules throws an ERROR
         value 'abcd' // invalid cron expression for value in schedule throws an ERROR
       }
     }
@@ -52,7 +52,7 @@ hadoop {
   workflow('triggerFail2') {
     trigger('trigger3') {
       maxWaitMins 9999999 // really high maxWaitMins throws a WARN
-      schedule('schedule1') {
+      schedule {
         value '*/30 0 1 ? * *'// really small cron interval throws an ERROR
       }
       daliDependency('dali-data-dep') {

--- a/hadoop-plugin-test/src/main/gradle/negative/triggerCheck.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/triggerCheck.gradle
@@ -12,12 +12,10 @@ buildscript {
 
 apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
 
-// Simple flow for testing trigger creation
-
-// TODO reallocf negative cases for Cheng's negative cases in AZ
+// Negative cases for trigger creation
 
 hadoop {
-  buildPath "jobs/triggerFlow"
+  buildPath "jobs/triggerCheck"
   cleanPath false
 
   generateYamlOutput true
@@ -51,23 +49,6 @@ hadoop {
     targets 'shellBash'
   }
 
-/**
- * The TriggerChecker rule checks the following:
- * <ul>
- *   <li>Trigger specific
- *   <li>WARN if a trigger maxWaitMins is greater than 10 days (14400) - will be set to 10 days
- *       by Azkaban.</li>
- *   <li>ERROR if a trigger schedule value has an interval smaller than 1 minute.</li>
- *   <li>ERROR if a trigger dependency name is not unique.</li>
- *   <li>ERROR if a trigger dependency config (type + params) is not unique.</li>
- *   <li>
- *   <li>DaliDatasetDependency specific
- *   <li>ERROR if a trigger dali dataset dependency window less than one.</li>
- *   <li>ERROR if a trigger dali dataset dependency delay less than zero.</li>
- *   <li>ERROR if a trigger dali dataset dependency unit is not 'daily' or 'hourly'.</li>
- *   <li>ERROR if a trigger dali dataset dependency ignoreLocation is not 'true' or 'false'.</li>
- * </ul>
- */
   workflow('triggerFail2') {
     trigger('trigger3') {
       maxWaitMins 9999999 // really high maxWaitMins throws a WARN

--- a/hadoop-plugin-test/src/main/gradle/negative/triggerCheck.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/triggerCheck.gradle
@@ -1,0 +1,105 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+    classpath 'org.quartz-scheduler:quartz:2.2.1'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Simple flow for testing trigger creation
+
+// TODO reallocf negative cases for Cheng's negative cases in AZ
+
+hadoop {
+  buildPath "jobs/triggerFlow"
+  cleanPath false
+
+  generateYamlOutput true
+
+  workflow('triggerFail1') {
+    trigger('trigger1') {
+      // no maxWaitMins throws an ERROR
+      // no schedule throws an ERROR
+      daliDatasetDependency('dali-data-dep') {
+        // no dali dataset dependency view throws an ERROR
+        // no dali dataset dependency window throws an ERROR
+        // no dali dataset dependency delay throws an ERROR
+        // no dali dataset dependency unit throws an ERROR
+      }
+    }
+
+    trigger('trigger2') { // two defined triggers throws an ERROR
+      maxWaitMins 0 // maxWaitMins less than 1 throws an ERROR
+      schedule('schedule1') {
+        // no schedule value throws an ERROR
+      }
+      schedule('schedule2') { // two schedules throws an ERROR
+        value 'abcd' // invalid cron expression for value in schedule throws an ERROR
+      }
+    }
+
+    commandJob('shellBash') {
+      uses 'bash ./sample_script.sh'
+    }
+
+    targets 'shellBash'
+  }
+
+/**
+ * The TriggerChecker rule checks the following:
+ * <ul>
+ *   <li>Trigger specific
+ *   <li>WARN if a trigger maxWaitMins is greater than 10 days (14400) - will be set to 10 days
+ *       by Azkaban.</li>
+ *   <li>ERROR if a trigger schedule value has an interval smaller than 1 minute.</li>
+ *   <li>ERROR if a trigger dependency name is not unique.</li>
+ *   <li>ERROR if a trigger dependency config (type + params) is not unique.</li>
+ *   <li>
+ *   <li>DaliDatasetDependency specific
+ *   <li>ERROR if a trigger dali dataset dependency window less than one.</li>
+ *   <li>ERROR if a trigger dali dataset dependency delay less than zero.</li>
+ *   <li>ERROR if a trigger dali dataset dependency unit is not 'daily' or 'hourly'.</li>
+ *   <li>ERROR if a trigger dali dataset dependency ignoreLocation is not 'true' or 'false'.</li>
+ * </ul>
+ */
+  workflow('triggerFail2') {
+    trigger('trigger3') {
+      maxWaitMins 9999999 // really high maxWaitMins throws a WARN
+      schedule('schedule1') {
+        value '*/30 0 1 ? * *'// really small cron interval throws an ERROR
+      }
+      daliDatasetDependency('dali-data-dep') {
+        view 'test'
+        window 0 // dali dataset dependency window less than 1 throws an ERROR
+        delay '-1' as int // dali dataset dependency delay less than 0 throws an ERROR
+        unit 'fail' // dali dataset dependency unit not 'daily' or 'hourly' throws an ERROR
+        ignoreLocation 'untrue'// dali dataset dependency ignoreLocation not 'true' or 'false'
+                               // throws an ERROR
+      }
+      daliDatasetDependency('dali-data-dep') { // two dependencies with same name throws an ERROR
+        view 'test'
+        window 1
+        delay 0
+        unit 'daily'
+      }
+      daliDatasetDependency('dali-data-dep2') { // two dependencies with same config throws an ERROR
+        view 'test'
+        window 1
+        delay 0
+        unit 'daily'
+      }
+    }
+
+    commandJob('shellPwd') {
+      uses 'pwd'
+    }
+
+    targets 'shellPwd'
+  }
+}

--- a/hadoop-plugin-test/src/main/gradle/negative/triggerCheck.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/triggerCheck.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
-    // Must manually specify snakeyaml for testing, not required for users
+    // Must manually specify snakeyaml and quartz-scheduler for testing, not required for users
     classpath 'org.yaml:snakeyaml:1.18'
     classpath 'org.quartz-scheduler:quartz:2.2.1'
   }
@@ -24,11 +24,11 @@ hadoop {
     trigger('trigger1') {
       // no maxWaitMins throws an ERROR
       // no schedule throws an ERROR
-      daliDatasetDependency('dali-data-dep') {
-        // no dali dataset dependency view throws an ERROR
-        // no dali dataset dependency window throws an ERROR
-        // no dali dataset dependency delay throws an ERROR
-        // no dali dataset dependency unit throws an ERROR
+      daliDependency('dali-data-dep') {
+        // no dali dependency view throws an ERROR
+        // no dali dependency window throws an ERROR
+        // no dali dependency delay throws an ERROR
+        // no dali dependency unit throws an ERROR
       }
     }
 
@@ -55,21 +55,19 @@ hadoop {
       schedule('schedule1') {
         value '*/30 0 1 ? * *'// really small cron interval throws an ERROR
       }
-      daliDatasetDependency('dali-data-dep') {
+      daliDependency('dali-data-dep') {
         view 'test'
-        window 0 // dali dataset dependency window less than 1 throws an ERROR
-        delay '-1' as int // dali dataset dependency delay less than 0 throws an ERROR
-        unit 'fail' // dali dataset dependency unit not 'daily' or 'hourly' throws an ERROR
-        ignoreLocation 'untrue'// dali dataset dependency ignoreLocation not 'true' or 'false'
-                               // throws an ERROR
+        window 0 // dali dependency window less than 1 throws an ERROR
+        delay '-1' as int // dali dependency delay less than 0 throws an ERROR
+        unit 'fail' // dali dependency unit not 'daily' or 'hourly' throws an ERROR
       }
-      daliDatasetDependency('dali-data-dep') { // two dependencies with same name throws an ERROR
+      daliDependency('dali-data-dep') { // two dependencies with same name throws an ERROR
         view 'test'
         window 1
         delay 0
         unit 'daily'
       }
-      daliDatasetDependency('dali-data-dep2') { // two dependencies with same config throws an ERROR
+      daliDependency('dali-data-dep2') { // two dependencies with same config throws an ERROR
         view 'test'
         window 1
         delay 0

--- a/hadoop-plugin-test/src/main/gradle/positive/triggerFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/triggerFlow.gradle
@@ -23,7 +23,7 @@ hadoop {
   workflow('triggerFlow') {
     trigger('trigger') {
       maxWaitMins 5
-      schedule('schedule') {
+      schedule {
         value '0 0 1 ? * *'
       }
       daliDependency('search-impression') {

--- a/hadoop-plugin-test/src/main/gradle/positive/triggerFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/triggerFlow.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
-    // Must manually specify snakeyaml for testing, not required for users
+    // Must manually specify snakeyaml and quartz-scheduler for testing, not required for users
     classpath 'org.yaml:snakeyaml:1.18'
     classpath 'org.quartz-scheduler:quartz:2.2.1'
   }
@@ -26,14 +26,14 @@ hadoop {
       schedule('schedule') {
         value '0 0 1 ? * *'
       }
-      daliDatasetDependency('search-impression') {
+      daliDependency('search-impression') {
         view 'search_mp_versioned.search_impression_event_0_0_47' // required
         delay 1 // required
         window 1 // required
         unit 'daily' // required - must be either 'daily' or 'weekly'
-        ignoreLocation 'true' // not required - must be either 'true' or 'false'
+        ignoreLocation true // not required - must be either true or false
       }
-      daliDatasetDependency('other-name') {
+      daliDependency('other-name') {
         view 'another dataset'
         delay 1
         window 7

--- a/hadoop-plugin-test/src/main/gradle/positive/triggerFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/triggerFlow.gradle
@@ -14,8 +14,6 @@ apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
 
 // Simple flow for testing trigger creation
 
-// TODO reallocf negative cases for Cheng's negative cases in AZ
-
 hadoop {
   buildPath "jobs/triggerFlow"
   cleanPath false

--- a/hadoop-plugin-test/src/main/gradle/positive/triggerFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/triggerFlow.gradle
@@ -1,0 +1,64 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Simple flow for testing trigger creation
+
+// TODO reallocf negative cases for Cheng's negative cases in AZ
+
+hadoop {
+  buildPath "jobs/triggerFlow"
+  cleanPath false
+
+  generateYamlOutput true
+
+  workflow('triggerFlow') {
+    trigger('trigger') {
+      maxWaitMins 5
+      schedule('schedule') {
+        value '0 0 1 ? * *'
+      }
+      daliDatasetDependency('search-impression') {
+        view 'search_mp_versioned.search_impression_event_0_0_47' // required
+        delay 1 // required
+        window 1 // required
+        unit 'daily' // not required - must be either 'daily' or 'weekly'
+        ignoreLocation 'true' // not required - must be either 'true' or 'false'
+      }
+      daliDatasetDependency('other-name') {
+        view 'another dataset'
+        delay 1
+        window 7
+      }
+    }
+
+    propertyFile('properties') {
+      set properties: [
+              'flow-level-parameter' : 'value'
+      ]
+    }
+
+    commandJob('shellBash') {
+      uses 'bash ./sample_script.sh'
+    }
+
+    commandJob('shellPwd') {
+      uses 'pwd'
+    }
+
+    commandJob('shellEcho') {
+      uses 'echo "This is an echoed text."'
+    }
+
+    targets 'shellPwd', 'shellEcho', 'shellBash'
+  }
+}

--- a/hadoop-plugin-test/src/main/gradle/positive/triggerFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/triggerFlow.gradle
@@ -6,6 +6,7 @@ buildscript {
     classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
     // Must manually specify snakeyaml for testing, not required for users
     classpath 'org.yaml:snakeyaml:1.18'
+    classpath 'org.quartz-scheduler:quartz:2.2.1'
   }
 }
 
@@ -31,13 +32,14 @@ hadoop {
         view 'search_mp_versioned.search_impression_event_0_0_47' // required
         delay 1 // required
         window 1 // required
-        unit 'daily' // not required - must be either 'daily' or 'weekly'
+        unit 'daily' // required - must be either 'daily' or 'weekly'
         ignoreLocation 'true' // not required - must be either 'true' or 'false'
       }
       daliDatasetDependency('other-name') {
         view 'another dataset'
         delay 1
         window 7
+        unit 'hourly'
       }
     }
 

--- a/hadoop-plugin/build.gradle
+++ b/hadoop-plugin/build.gradle
@@ -40,6 +40,7 @@ dependencies {
   compile('org.apache.hadoop:hadoop-hdfs:2.3.0') { transitive = false }
   compile 'org.apache.oozie:oozie-client:4.2.0'
   compile('org.apache.pig:pig:0.15.0') { transitive = false }
+  compile 'org.quartz-scheduler:quartz:2.2.1'
   compile 'org.yaml:snakeyaml:1.18'
 
   runtime 'com.googlecode.json-simple:json-simple:1.1'

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -27,7 +27,7 @@ import com.linkedin.gradle.hadoopdsl.Workflow;
 import com.linkedin.gradle.hadoopdsl.job.Job;
 import com.linkedin.gradle.hadoopdsl.job.StartJob;
 import com.linkedin.gradle.hadoopdsl.job.SubFlowJob;
-import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDatasetDependency;
+import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDependency;
 import com.linkedin.gradle.hadoopdsl.triggerDependency.TriggerDependency;
 import org.gradle.api.Project;
 import org.yaml.snakeyaml.DumperOptions;
@@ -284,15 +284,15 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     return yamlizedSchedule;
   }
 
-  Map yamlizeTriggerDependency(DaliDatasetDependency daliDatasetDependency) {
+  Map yamlizeTriggerDependency(DaliDependency daliDependency) {
     Map yamlizedTriggerDependency = [:];
 
     // Add trigger dependency name
-    yamlizedTriggerDependency["name"] = daliDatasetDependency.name;
+    yamlizedTriggerDependency["name"] = daliDependency.name;
     // Add trigger dependency type
-    yamlizedTriggerDependency["type"] = daliDatasetDependency.type;
+    yamlizedTriggerDependency["type"] = daliDependency.type;
     // Add trigger dependency params
-    yamlizedTriggerDependency["params"] = daliDatasetDependency.params;
+    yamlizedTriggerDependency["params"] = daliDependency.params;
     return yamlizedTriggerDependency;
   }
 

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -284,6 +284,12 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     return yamlizedSchedule;
   }
 
+  /**
+   * Take in dali dependency and turn into map to be output in yaml file.
+   *
+   * @param daliDependency Dali dependency to be turned into map.
+   * @return Map representing dali dependency to be output in yaml file.
+   */
   Map yamlizeTriggerDependency(DaliDependency daliDependency) {
     Map yamlizedTriggerDependency = [:];
 

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -26,8 +26,8 @@ import com.linkedin.gradle.hadoopdsl.Trigger;
 import com.linkedin.gradle.hadoopdsl.Workflow;
 import com.linkedin.gradle.hadoopdsl.job.Job;
 import com.linkedin.gradle.hadoopdsl.job.StartJob;
-import com.linkedin.gradle.hadoopdsl.job.SubFlowJob
-import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDatasetDependency
+import com.linkedin.gradle.hadoopdsl.job.SubFlowJob;
+import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDatasetDependency;
 import com.linkedin.gradle.hadoopdsl.triggerDependency.TriggerDependency;
 import org.gradle.api.Project;
 import org.yaml.snakeyaml.DumperOptions;
@@ -257,7 +257,7 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     // Add maximum number of minutes the trigger will wait before it's automatically cancelled
     yamlizedTrigger["maxWaitMins"] = trigger.maxWaitMins;
     // Add trigger schedule
-    yamlizedTrigger["schedule"] = yamlizeSchedule(trigger.schedule);
+    yamlizedTrigger["schedule"] = yamlizeSchedule(trigger.schedules[0]);
     // Add trigger dependencies if there are any
     if (!trigger.triggerDependencies.isEmpty()) {
       List<Map> yamlizedTriggerDependencies = [];

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -20,8 +20,8 @@ import com.linkedin.gradle.hadoopdsl.BaseNamedScopeContainer;
 import com.linkedin.gradle.hadoopdsl.HadoopDslExtension;
 import com.linkedin.gradle.hadoopdsl.NamedScope;
 import com.linkedin.gradle.hadoopdsl.Namespace;
-import com.linkedin.gradle.hadoopdsl.Properties
-import com.linkedin.gradle.hadoopdsl.Schedule
+import com.linkedin.gradle.hadoopdsl.Properties;
+import com.linkedin.gradle.hadoopdsl.Schedule;
 import com.linkedin.gradle.hadoopdsl.Trigger;
 import com.linkedin.gradle.hadoopdsl.Workflow;
 import com.linkedin.gradle.hadoopdsl.job.Job;
@@ -184,7 +184,6 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
       yamlizedWorkflow["name"] = workflow.name;
     }
     // Add trigger if not subflow and there is a trigger defined in the workflow
-    // TODO reallocf is this the right way to handle multiple defined triggers?
     if (!isSubflow && !workflow.triggers.isEmpty()) {
       yamlizedWorkflow["trigger"] = yamlizeTrigger(workflow.triggers[0]);
     }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
@@ -37,7 +37,6 @@ import com.linkedin.gradle.hadoopdsl.job.TensorFlowJob;
 import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob;
 import com.linkedin.gradle.hadoopdsl.job.VenicePushJob;
 import com.linkedin.gradle.hadoopdsl.job.VoldemortBuildPushJob;
-import com.linkedin.gradle.hadoopdsl.triggerDependency.TriggerDependency;
 
 import org.gradle.api.Project;
 

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
@@ -37,6 +37,7 @@ import com.linkedin.gradle.hadoopdsl.job.TensorFlowJob;
 import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob;
 import com.linkedin.gradle.hadoopdsl.job.VenicePushJob;
 import com.linkedin.gradle.hadoopdsl.job.VoldemortBuildPushJob;
+import com.linkedin.gradle.hadoopdsl.triggerDependency.TriggerDependency;
 
 import org.gradle.api.Project;
 
@@ -55,6 +56,7 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
   List<Properties> properties;
   List<PropertySet> propertySets;
   List<Workflow> workflows;
+  List<Trigger> triggers;
 
   /**
    * Constructor for the BaseNamedScopeContainer.
@@ -75,6 +77,7 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
     this.properties = new ArrayList<Properties>();
     this.propertySets = new ArrayList<PropertySet>();
     this.workflows = new ArrayList<Workflow>();
+    this.triggers = new ArrayList<Trigger>();
   }
 
   /**
@@ -93,6 +96,7 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
     this.properties = new ArrayList<Properties>();
     this.propertySets = new ArrayList<PropertySet>();
     this.workflows = new ArrayList<Workflow>();
+    this.triggers = new ArrayList<Trigger>();
   }
 
   /**
@@ -129,11 +133,16 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
       scope.unbind(workflow.name);
     }
 
+    for (Trigger trigger : triggers) {
+      scope.unbind(trigger.name);
+    }
+
     jobs.clear();
     namespaces.clear();
     properties.clear();
     propertySets.clear();
     workflows.clear();
+    triggers.clear();
 
     return this;
   }
@@ -181,6 +190,12 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
     for (Workflow workflow : workflows) {
       Workflow clone = workflow.clone(container.getScope());
       container.workflows.add(clone);
+      container.scope.bind(clone.name, clone);
+    }
+
+    for (Trigger trigger : triggers) {
+      Trigger clone = trigger.clone();
+      container.triggers.add(clone);
       container.scope.bind(clone.name, clone);
     }
 
@@ -325,6 +340,33 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
   }
 
   /**
+   * Helper method to clone a Trigger in the DSL.
+   *
+   * @param name The name of the object to clone
+   * @return The cloned object
+   */
+  protected Trigger cloneTrigger(String name) {
+    Trigger trigger = (Trigger)scope.lookup(name);
+    if (trigger == null) {
+      throw new Exception("Could not find trigger ${name} from scope ${scope.levelName}");
+    }
+    return trigger.clone();
+  }
+
+  /**
+   * Helper method to clone a Trigger in the DSL and give it a new name.
+   *
+   * @param name The name of the object to clone
+   * @param rename The new name to give the object
+   * @return The cloned object
+   */
+  protected Trigger cloneTrigger(String name, String rename) {
+    Trigger trigger = cloneTrigger(name);
+    trigger.name = rename;
+    return trigger;
+  }
+
+  /**
    * Helper method to configure a Job in the DSL. Can be called by subclasses to configure custom
    * Job subclass types.
    *
@@ -397,6 +439,21 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
     project.configure(workflow, configure);
     workflows.add(workflow);
     return workflow;
+  }
+
+  /**
+   * Helper method to configure a Trigger in the DSL. Can be called by subclasses to configure
+   * custom Trigger subclass types.
+   *
+   * @param trigger The trigger to configure
+   * @param configure The configuration closure
+   * @return The input trigger, which is now configured
+   */
+  protected Trigger configureTrigger(Trigger trigger, Closure configure) {
+    scope.bind(trigger.name, trigger);
+    project.configure(trigger, configure);
+    triggers.add(trigger);
+    return trigger;
   }
 
   /**
@@ -537,6 +594,34 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
   @HadoopDslMethod
   Workflow addWorkflow(String name, String rename, @DelegatesTo(Workflow) Closure configure) {
     return configureWorkflow(cloneWorkflow(name, rename), configure);
+  }
+
+  /**
+   * DSL addTrigger method. Looks up the trigger with given name, clones it, configures the clone
+   * with the given configuration closure and binds the clone in scope.
+   *
+   * @param name The trigger name to lookup
+   * @param configure The configuration closure
+   * @return The cloned and configured trigger that was bound in scope
+   */
+  @HadoopDslMethod
+  Trigger addTrigger(String name, @DelegatesTo(Trigger) Closure configure) {
+    return configureTrigger(cloneTrigger(name), configure);
+  }
+
+  /**
+   * DSL addTrigger method. Looks up the trigger with given name, clones it, renames the clone to
+   * the specified name, configures the clone with the given configuration closure and binds the
+   * clone in scope.
+   *
+   * @param name The trigger name to lookup
+   * @param rename The new name to give the cloned trigger
+   * @param configure The configuration closure
+   * @return The cloned, renamed and configured trigger that was bound in scope
+   */
+  @HadoopDslMethod
+  Trigger addTrigger(String name, String rename, @DelegatesTo(Trigger) Closure configure) {
+    return configureTrigger(cloneTrigger(name, rename), configure);
   }
 
   /**
@@ -1010,5 +1095,17 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
   @HadoopDslMethod
   TensorFlowJob tensorFlowJob(String name, @DelegatesTo(TensorFlowJob) Closure configure) {
     return ((TensorFlowJob)configureJob(factory.makeTensorFlowJob(name), configure));
+  }
+
+  /**
+   * DSL trigger method. Creates a Trigger in scope with the given name and configuration.
+   *
+   * @param name The trigger name
+   * @param configure The configuration closure
+   * @return The new trigger
+   */
+  @HadoopDslMethod
+  Trigger trigger(String name, @DelegatesTo(Trigger) Closure configure) {
+    return configureTrigger(factory.makeTrigger(name, project), configure);
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslChecker.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslChecker.groovy
@@ -19,6 +19,7 @@ import com.linkedin.gradle.hadoopdsl.checker.JobDependencyChecker;
 import com.linkedin.gradle.hadoopdsl.checker.PropertySetChecker;
 import com.linkedin.gradle.hadoopdsl.checker.RequiredFieldsChecker;
 import com.linkedin.gradle.hadoopdsl.checker.RequiredParametersChecker;
+import com.linkedin.gradle.hadoopdsl.checker.TriggerChecker;
 import com.linkedin.gradle.hadoopdsl.checker.ValidFieldsChecker;
 import com.linkedin.gradle.hadoopdsl.checker.ValidNameChecker;
 import com.linkedin.gradle.hadoopdsl.checker.WorkflowJobChecker;
@@ -37,6 +38,7 @@ import org.gradle.api.Project;
  *   <li>WorkflowJobChecker: checks various properties of workflows</li>
  *   <li>JobDependencyChecker: checks various properties of jobs, such as no cyclic dependencies and potential read-before-write race conditions</li>
  *   <li>PropertySetChecker: checks that property files and jobs that declare baseProperties refer to valid property sets</li>
+ *   <li>TriggerChecker: checks that the trigger schedules and dependencies are properly defined</li>
  * </ul>
  */
 class HadoopDslChecker extends BaseStaticChecker {
@@ -64,6 +66,7 @@ class HadoopDslChecker extends BaseStaticChecker {
     checks.add(makeJobDependencyChecker());
     checks.add(makePropertySetChecker());
     checks.add(makeValidFieldsChecker());
+    checks.add(makeTriggerChecker());
     return checks;
   }
 
@@ -150,5 +153,15 @@ class HadoopDslChecker extends BaseStaticChecker {
    */
   WorkflowJobChecker makeWorkflowJobChecker() {
     return new WorkflowJobChecker(project);
+  }
+
+  /**
+   * Factory method to build the TriggerChecker check. Allows subclasses to provide a custom
+   * implementation of this check.
+   *
+   * @return The TriggerChecker check
+   */
+  TriggerChecker makeTriggerChecker() {
+    return new TriggerChecker(project);
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslChecker.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslChecker.groovy
@@ -38,7 +38,7 @@ import org.gradle.api.Project;
  *   <li>WorkflowJobChecker: checks various properties of workflows</li>
  *   <li>JobDependencyChecker: checks various properties of jobs, such as no cyclic dependencies and potential read-before-write race conditions</li>
  *   <li>PropertySetChecker: checks that property files and jobs that declare baseProperties refer to valid property sets</li>
- *   <li>TriggerChecker: checks that the trigger schedules and dependencies are properly defined</li>
+ *   <li>TriggerChecker: checks that the triggers and their  dependencies are properly defined</li>
  * </ul>
  */
 class HadoopDslChecker extends BaseStaticChecker {

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslFactory.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslFactory.groovy
@@ -369,6 +369,18 @@ class HadoopDslFactory {
   }
 
   /**
+   * Factory method to build a Trigger.
+   *
+   * @param name The trigger name
+   * @param project The Gradle project
+   * @param parentScope The parent scope
+   * @return The trigger
+   */
+  Trigger makeTrigger(String name, Project project) {
+    return new Trigger(name, project);
+  }
+
+  /**
    * Factory method to build an Assertion.
    *
    * @param name The Assertion name

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
@@ -105,12 +105,14 @@ class HadoopDslPlugin extends BaseNamedScopeContainer implements Plugin<Project>
     project.extensions.add("addPropertyFile", this.&addPropertyFile);
     project.extensions.add("addPropertySet", this.&addPropertySet);
     project.extensions.add("addWorkflow", this.&addWorkflow);
+    project.extensions.add("addTrigger", this.&addTrigger);
     project.extensions.add("lookup", this.&lookup);
     project.extensions.add("lookupRef", this.&lookupRef);
     project.extensions.add("namespace", this.&namespace);
     project.extensions.add("propertyFile", this.&propertyFile);
     project.extensions.add("propertySet", this.&propertySet);
     project.extensions.add("workflow", this.&workflow);
+    project.extensions.add("trigger", this.&trigger);
     project.extensions.add("commandJob", this.&commandJob);
     project.extensions.add("gobblinJob", this.&gobblinJob);
     project.extensions.add("hadoopJavaJob", this.&hadoopJavaJob);

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Schedule.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Schedule.groovy
@@ -2,7 +2,13 @@ package com.linkedin.gradle.hadoopdsl;
 
 import com.linkedin.gradle.hadoopdsl.HadoopDslMethod;
 
-// check to see if valid schedule?
+/**
+ * Represents the cron schedule that Azkaban uses to schedule jobs by time.
+ *
+ * If paired with a dependency in a Trigger, the schedule signifies when the trigger is created.
+ * At this point, the trigger will start looking to see if the dependencies are met which then
+ * launches the flow.
+ */
 class Schedule {
   String name;
   String type;

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Schedule.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Schedule.groovy
@@ -11,7 +11,7 @@ class Schedule {
   Schedule(String name) {
     this.name = name;
     this.type = "cron";
-    this.value = null; // TODO reallocf validate?
+    this.value = null;
   }
 
   @HadoopDslMethod

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Schedule.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Schedule.groovy
@@ -10,12 +10,10 @@ import com.linkedin.gradle.hadoopdsl.HadoopDslMethod;
  * launches the flow.
  */
 class Schedule {
-  String name;
   String type;
   String value;
 
-  Schedule(String name) {
-    this.name = name;
+  Schedule() {
     this.type = "cron";
     this.value = null;
   }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Schedule.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Schedule.groovy
@@ -1,0 +1,21 @@
+package com.linkedin.gradle.hadoopdsl;
+
+import com.linkedin.gradle.hadoopdsl.HadoopDslMethod;
+
+// check to see if valid schedule?
+class Schedule {
+  String name;
+  String type;
+  String value;
+
+  Schedule(String name) {
+    this.name = name;
+    this.type = "cron";
+    this.value = null; // TODO reallocf validate?
+  }
+
+  @HadoopDslMethod
+  void value(String value) {
+    this.value = value;
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
@@ -24,9 +24,9 @@ class Trigger {
   Trigger(String name, Project project){
     this.name = name;
     this.project = project;
-    this.maxWaitMins = 0; // TODO reallocf verify >0 (required to be set by user)
+    this.maxWaitMins = 0;
     this.schedules = new ArrayList<Schedule>();
-    this.triggerDependencies = new ArrayList<TriggerDependency>(); // TODO reallocf any verify?
+    this.triggerDependencies = new ArrayList<TriggerDependency>();
   }
 
   protected Trigger clone() {

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
@@ -51,8 +51,8 @@ class Trigger {
   }
 
   @HadoopDslMethod
-  void schedule(String name, @DelegatesTo(Schedule) Closure configure) {
-    Schedule schedule = new Schedule(name);
+  void schedule(@DelegatesTo(Schedule) Closure configure) {
+    Schedule schedule = new Schedule();
     project.configure(schedule, configure);
     this.schedules.add(schedule);
   }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
@@ -13,18 +13,19 @@ class Trigger {
   int maxWaitMins;
 
   // Used to determine when the triggerInstance is created in Azkaban.
-  Schedule schedule;
+  // Should only be 1 defined.
+  List<Schedule> schedules;
 
   // Used to determine what is necessary for the triggerInstance in Azkaban to be satisfied.
   // Once satisfied, the triggerInstance will launch the Azkaban flow.
   // For example, a Data Dependency will be included here.
-  List triggerDependencies;
+  List<TriggerDependency> triggerDependencies;
 
   Trigger(String name, Project project){
     this.name = name;
     this.project = project;
     this.maxWaitMins = 0; // TODO reallocf verify >0 (required to be set by user)
-    this.schedule = null;
+    this.schedules = new ArrayList<Schedule>();
     this.triggerDependencies = new ArrayList<TriggerDependency>(); // TODO reallocf any verify?
   }
 
@@ -34,7 +35,7 @@ class Trigger {
 
   protected Trigger clone(Trigger cloneTrigger) {
     cloneTrigger.maxWaitMins = maxWaitMins;
-    cloneTrigger.schedule = schedule;
+    cloneTrigger.schedules = schedules;
     cloneTrigger.triggerDependencies = triggerDependencies;
     return cloneTrigger;
   }
@@ -48,7 +49,7 @@ class Trigger {
   void schedule(String name, @DelegatesTo(Schedule) Closure configure) {
     Schedule schedule = new Schedule(name);
     project.configure(schedule, configure);
-    this.schedule = schedule;
+    this.schedules.add(schedule);
   }
 
   @HadoopDslMethod

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
@@ -1,6 +1,6 @@
-package com.linkedin.gradle.hadoopdsl;
+package com.linkedin.gradle.hadoopdsl
 
-import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDatasetDependency;
+import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDependency;
 import com.linkedin.gradle.hadoopdsl.triggerDependency.TriggerDependency;
 
 import org.gradle.api.Project;
@@ -53,9 +53,9 @@ class Trigger {
   }
 
   @HadoopDslMethod
-  void daliDatasetDependency(String name, @DelegatesTo(DaliDatasetDependency) Closure configure) {
-    DaliDatasetDependency daliDatasetDependency = new DaliDatasetDependency(name);
-    project.configure(daliDatasetDependency, configure);
-    triggerDependencies.add(daliDatasetDependency);
+  void daliDependency(String name, @DelegatesTo(DaliDependency) Closure configure) {
+    DaliDependency daliDependency = new DaliDependency(name);
+    project.configure(daliDependency, configure);
+    triggerDependencies.add(daliDependency);
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
@@ -1,0 +1,60 @@
+package com.linkedin.gradle.hadoopdsl;
+
+import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDatasetDependency;
+import com.linkedin.gradle.hadoopdsl.triggerDependency.TriggerDependency;
+
+import org.gradle.api.Project;
+
+class Trigger {
+  String name;
+  Project project;
+
+  // The number of minutes the trigger will exist within Azkaban before being deleted.
+  int maxWaitMins;
+
+  // Used to determine when the triggerInstance is created in Azkaban.
+  Schedule schedule;
+
+  // Used to determine what is necessary for the triggerInstance in Azkaban to be satisfied.
+  // Once satisfied, the triggerInstance will launch the Azkaban flow.
+  // For example, a Data Dependency will be included here.
+  List triggerDependencies;
+
+  Trigger(String name, Project project){
+    this.name = name;
+    this.project = project;
+    this.maxWaitMins = 0; // TODO reallocf verify >0 (required to be set by user)
+    this.schedule = null;
+    this.triggerDependencies = new ArrayList<TriggerDependency>(); // TODO reallocf any verify?
+  }
+
+  protected Trigger clone() {
+    return clone(new Trigger(name, project));
+  }
+
+  protected Trigger clone(Trigger cloneTrigger) {
+    cloneTrigger.maxWaitMins = maxWaitMins;
+    cloneTrigger.schedule = schedule;
+    cloneTrigger.triggerDependencies = triggerDependencies;
+    return cloneTrigger;
+  }
+
+  @HadoopDslMethod
+  void maxWaitMins(int mins) {
+    maxWaitMins = mins;
+  }
+
+  @HadoopDslMethod
+  void schedule(String name, @DelegatesTo(Schedule) Closure configure) {
+    Schedule schedule = new Schedule(name);
+    project.configure(schedule, configure);
+    this.schedule = schedule;
+  }
+
+  @HadoopDslMethod
+  void daliDatasetDependency(String name, @DelegatesTo(DaliDatasetDependency) Closure configure) {
+    DaliDatasetDependency daliDatasetDependency = new DaliDatasetDependency(name);
+    project.configure(daliDatasetDependency, configure);
+    triggerDependencies.add(daliDatasetDependency);
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Trigger.groovy
@@ -5,6 +5,12 @@ import com.linkedin.gradle.hadoopdsl.triggerDependency.TriggerDependency;
 
 import org.gradle.api.Project;
 
+/**
+ * Triggers are used by Azkaban to know when to automatically launch flows (aka trigger them).
+ *
+ * In Azkaban, triggers are created based on their defined schedule (cron schedule) then actually
+ * launches the flow when all the dependencies in the trigger are fulfilled.
+ */
 class Trigger {
   String name;
   Project project;
@@ -18,7 +24,6 @@ class Trigger {
 
   // Used to determine what is necessary for the triggerInstance in Azkaban to be satisfied.
   // Once satisfied, the triggerInstance will launch the Azkaban flow.
-  // For example, a Data Dependency will be included here.
   List<TriggerDependency> triggerDependencies;
 
   Trigger(String name, Project project){

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/TriggerChecker.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/TriggerChecker.groovy
@@ -68,7 +68,7 @@ class TriggerChecker extends BaseStaticChecker {
     }
 
     // Indicate to the static checker whether or not we passed all the static checks
-    foundError |= workflowError
+    foundError |= workflowError;
   }
 
   boolean checkTrigger(Trigger trigger) {

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/TriggerChecker.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/TriggerChecker.groovy
@@ -136,17 +136,17 @@ class TriggerChecker extends BaseStaticChecker {
     trigger.schedules.each { Schedule schedule ->
       // ERROR if no schedule value defined
       if (schedule.value == null) {
-        project.logger.lifecycle("TriggerChecker ERROR: Schedule ${schedule.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define 'value'.");
+        project.logger.lifecycle("TriggerChecker ERROR: Schedule in Trigger ${trigger.name} in Workflow ${workflow.name} must define 'value'.");
         checkScheduleError = true;
       }
       // ERROR if schedule value is not a valid cron expression
       else if (!CronExpression.isValidExpression(schedule.value)) {
-        project.logger.lifecycle("TriggerChecker ERROR: Schedule ${schedule.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define 'value' as a valid cron expression.");
+        project.logger.lifecycle("TriggerChecker ERROR: Schedule in Trigger ${trigger.name} in Workflow ${workflow.name} must define 'value' as a valid cron expression.");
         checkScheduleError = true;
       }
       // ERROR if schedule value specifies a cron expression that runs more frequently than once per minute
       else if (schedule.value.split("\\s+")[0] != "0") {
-        project.logger.lifecycle("TriggerChecker ERROR: Schedule ${schedule.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define interval of flow trigger to be larger than 1 minute.");
+        project.logger.lifecycle("TriggerChecker ERROR: Schedule in Trigger ${trigger.name} in Workflow ${workflow.name} must define interval of flow trigger to be larger than 1 minute.");
         checkScheduleError = true;
       }
     }
@@ -182,8 +182,8 @@ class TriggerChecker extends BaseStaticChecker {
       project.logger.lifecycle("TriggerChecker ERROR: DaliDependency ${daliDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must have a window greater than 0.");
       checkDaliDependencyError = true;
     }
-    // ERROR if dali dataset dependency has a window less than one.
-    if (daliDependency.params["delay"] < 1) {
+    // ERROR if dali dependency has a delay less than zero.
+    if (daliDependency.params["delay"] < 0) {
       project.logger.lifecycle("TriggerChecker ERROR: DaliDependency ${daliDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must have a nonnegative delay.");
       checkDaliDependencyError = true;
     }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/TriggerChecker.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/TriggerChecker.groovy
@@ -4,7 +4,7 @@ import com.linkedin.gradle.hadoopdsl.BaseStaticChecker;
 import com.linkedin.gradle.hadoopdsl.Schedule;
 import com.linkedin.gradle.hadoopdsl.Trigger;
 import com.linkedin.gradle.hadoopdsl.Workflow;
-import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDatasetDependency;
+import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDependency;
 import com.linkedin.gradle.hadoopdsl.triggerDependency.TriggerDependency;
 import org.gradle.api.Project;
 import org.quartz.CronExpression;
@@ -25,15 +25,14 @@ import org.quartz.CronExpression;
  *   <li>ERROR if a trigger dependency name is not unique.</li>
  *   <li>ERROR if a trigger dependency config (type + params) is not unique.</li>
  *   <li>
- *   <li>DaliDatasetDependency specific
- *   <li>ERROR if a trigger dali dataset dependency doesn't have a view.</li>
- *   <li>ERROR if a trigger dali dataset dependency doesn't have a window.</li>
- *   <li>ERROR if a trigger dali dataset dependency doesn't have a delay.</li>
- *   <li>ERROR if a trigger dali dataset dependency doesn't have a unit.</li>
- *   <li>ERROR if a trigger dali dataset dependency window less than one.</li>
- *   <li>ERROR if a trigger dali dataset dependency delay less than zero.</li>
- *   <li>ERROR if a trigger dali dataset dependency unit is not 'daily' or 'hourly'.</li>
- *   <li>ERROR if a trigger dali dataset dependency ignoreLocation is not 'true' or 'false'.</li>
+ *   <li>DaliDependency specific
+ *   <li>ERROR if a trigger dali dependency doesn't have a view.</li>
+ *   <li>ERROR if a trigger dali dependency doesn't have a window.</li>
+ *   <li>ERROR if a trigger dali dependency doesn't have a delay.</li>
+ *   <li>ERROR if a trigger dali dependency doesn't have a unit.</li>
+ *   <li>ERROR if a trigger dali dependency window less than one.</li>
+ *   <li>ERROR if a trigger dali dependency delay less than zero.</li>
+ *   <li>ERROR if a trigger dali dependency unit is not 'daily' or 'hourly'.</li>
  * </ul>
  */
 class TriggerChecker extends BaseStaticChecker {
@@ -95,8 +94,8 @@ class TriggerChecker extends BaseStaticChecker {
       }
       triggerDependencyConfigs.add(triggerDependencyConfig);
       // Check for trigger specific errors
-      if (triggerDependency.type == 'dali-dataset') {
-        triggerError |= checkDaliDatasetDependency((DaliDatasetDependency) triggerDependency);
+      if (triggerDependency.type == 'dali') {
+        triggerError |= checkDaliDependency((DaliDependency) triggerDependency);
       }
     }
 
@@ -155,53 +154,46 @@ class TriggerChecker extends BaseStaticChecker {
     return checkScheduleError;
   }
 
-  boolean checkDaliDatasetDependency(DaliDatasetDependency daliDatasetDependency) {
-    boolean checkDaliDatasetDependencyError = false;
+  boolean checkDaliDependency(DaliDependency daliDependency) {
+    boolean checkDaliDependencyError = false;
 
-    // ERROR if dali dataset dependency doesn't have a view
-    if (!daliDatasetDependency.params.containsKey("view")) {
-      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a view.");
-      checkDaliDatasetDependencyError = true;
+    // ERROR if dali dependency doesn't have a view
+    if (!daliDependency.params.containsKey("view")) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDependency ${daliDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a view.");
+      checkDaliDependencyError = true;
     }
-    // ERROR if dali dataset dependency doesn't have a window
-    if (!daliDatasetDependency.params.containsKey("window")) {
-      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a window.");
-      checkDaliDatasetDependencyError = true;
+    // ERROR if dali dependency doesn't have a window
+    if (!daliDependency.params.containsKey("window")) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDependency ${daliDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a window.");
+      checkDaliDependencyError = true;
     }
-    // ERROR if dali dataset dependency doesn't have a delay
-    if (!daliDatasetDependency.params.containsKey("delay")) {
-      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a delay.");
-      checkDaliDatasetDependencyError = true;
+    // ERROR if dali dependency doesn't have a delay
+    if (!daliDependency.params.containsKey("delay")) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDependency ${daliDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a delay.");
+      checkDaliDependencyError = true;
     }
-    // ERROR if dali dataset dependency doesn't have a unit
-    if (!daliDatasetDependency.params.containsKey("unit")) {
-      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a unit.");
-      checkDaliDatasetDependencyError = true;
+    // ERROR if dali dependency doesn't have a unit
+    if (!daliDependency.params.containsKey("unit")) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDependency ${daliDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a unit.");
+      checkDaliDependencyError = true;
+    }
+    // ERROR if dali dependency has a window less than one.
+    if (daliDependency.params["window"] < 1) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDependency ${daliDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must have a window greater than 0.");
+      checkDaliDependencyError = true;
     }
     // ERROR if dali dataset dependency has a window less than one.
-    if (daliDatasetDependency.params["window"] < 1) {
-      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must have a window greater than 0.");
-      checkDaliDatasetDependencyError = true;
+    if (daliDependency.params["delay"] < 1) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDependency ${daliDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must have a nonnegative delay.");
+      checkDaliDependencyError = true;
     }
-    // ERROR if dali dataset dependency has a window less than one.
-    if (daliDatasetDependency.params["delay"] < 1) {
-      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must have a nonnegative delay.");
-      checkDaliDatasetDependencyError = true;
-    }
-    // ERROR if dali dataset dependency has a unit that is neither 'daily' nor 'hourly'.
-    String unit = daliDatasetDependency.params["unit"];
+    // ERROR if dali dependency has a unit that is neither 'daily' nor 'hourly'.
+    String unit = daliDependency.params["unit"];
     if (unit != 'daily' && unit != 'hourly') {
-      project.logger.lifecycle("TriggerChecker ERROR: 'unit' value in DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} can only be set to 'daily' or 'hourly'.");
-      checkDaliDatasetDependencyError = true;
-    }
-    // ERROR if dali dataset dependency has an ignoreLocation that is neither 'daily' nor 'hourly'.
-    // if no ignoreLocation set, test passes (ignoreLocation not required
-    String ignoreLocation = daliDatasetDependency.params["ignoreLocation"];
-    if (ignoreLocation != null && ignoreLocation != 'true' && ignoreLocation != 'false') {
-      project.logger.lifecycle("TriggerChecker ERROR: 'ignoreLocation' value in DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} can only be set to 'true' or 'false'.");
-      checkDaliDatasetDependencyError = true;
+      project.logger.lifecycle("TriggerChecker ERROR: 'unit' value in DaliDependency ${daliDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} can only be set to 'daily' or 'hourly'.");
+      checkDaliDependencyError = true;
     }
 
-    return checkDaliDatasetDependencyError;
+    return checkDaliDependencyError;
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/TriggerChecker.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/checker/TriggerChecker.groovy
@@ -1,0 +1,207 @@
+package com.linkedin.gradle.hadoopdsl.checker;
+
+import com.linkedin.gradle.hadoopdsl.BaseStaticChecker;
+import com.linkedin.gradle.hadoopdsl.Schedule;
+import com.linkedin.gradle.hadoopdsl.Trigger;
+import com.linkedin.gradle.hadoopdsl.Workflow;
+import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDatasetDependency;
+import com.linkedin.gradle.hadoopdsl.triggerDependency.TriggerDependency;
+import org.gradle.api.Project;
+import org.quartz.CronExpression;
+
+/**
+ * The TriggerChecker rule checks the following:
+ * <ul>
+ *   <li>Trigger specific
+ *   <li>ERROR if more than 1 trigger is defined in a workflow.</li>
+ *   <li>ERROR if a trigger maxWaitMins doesn't exist or is less than 1.</li>
+ *   <li>WARN if a trigger maxWaitMins is greater than 10 days (14400) - will be set to 10 days
+ *       by Azkaban.</li>
+ *   <li>ERROR if a trigger schedule doesn't exist.</li>
+ *   <li>ERROR if more than one trigger schedule is defined for a trigger.</li>
+ *   <li>ERROR if a trigger schedule doesn't have a value.</li>
+ *   <li>ERROR if a trigger schedule value is not a valid cron expression.</li>
+ *   <li>ERROR if a trigger schedule value has an interval smaller than 1 minute.</li>
+ *   <li>ERROR if a trigger dependency name is not unique.</li>
+ *   <li>ERROR if a trigger dependency config (type + params) is not unique.</li>
+ *   <li>
+ *   <li>DaliDatasetDependency specific
+ *   <li>ERROR if a trigger dali dataset dependency doesn't have a view.</li>
+ *   <li>ERROR if a trigger dali dataset dependency doesn't have a window.</li>
+ *   <li>ERROR if a trigger dali dataset dependency doesn't have a delay.</li>
+ *   <li>ERROR if a trigger dali dataset dependency doesn't have a unit.</li>
+ *   <li>ERROR if a trigger dali dataset dependency window less than one.</li>
+ *   <li>ERROR if a trigger dali dataset dependency delay less than zero.</li>
+ *   <li>ERROR if a trigger dali dataset dependency unit is not 'daily' or 'hourly'.</li>
+ *   <li>ERROR if a trigger dali dataset dependency ignoreLocation is not 'true' or 'false'.</li>
+ * </ul>
+ */
+class TriggerChecker extends BaseStaticChecker {
+  private final int MIN_FLOW_TRIGGER_WAIT_TIME = 1;
+  private final int MAX_FLOW_TRIGGER_WAIT_TIME = 14400;
+
+  Workflow workflow;
+  Trigger trigger;
+
+  /**
+   * Constructor for the TriggerChecker.
+   *
+   * @param project The Gradle project
+   */
+  TriggerChecker(Project project) {
+    super(project);
+  }
+
+  @Override
+  void visitWorkflow(Workflow workflow) {
+    boolean workflowError = false;
+    this.workflow = workflow;
+
+    // ERROR if more than 1 trigger
+    if (workflow.triggers.size() > 1) {
+      project.logger.lifecycle("TriggerChecker ERROR: Workflow ${workflow.name} contains more than 1 trigger.");
+      workflowError = true;
+    }
+    // Test trigger (or multiple if defined) to see if properly defined
+    workflow.triggers.each { Trigger trigger ->
+      this.trigger = trigger;
+      workflowError |= checkTrigger(trigger);
+    }
+
+    // Indicate to the static checker whether or not we passed all the static checks
+    foundError |= workflowError
+  }
+
+  boolean checkTrigger(Trigger trigger) {
+    boolean triggerError = false;
+    this.trigger = trigger;
+    Set<String> triggerDependencyNames = [];
+    Set<String> triggerDependencyConfigs = [];
+
+    triggerError |= checkWaitMins();
+    triggerError |= checkSchedule();
+    trigger.triggerDependencies.each { TriggerDependency triggerDependency ->
+      // ERROR if dependency name is not unique
+      if (triggerDependency.name in triggerDependencyNames) {
+        project.logger.lifecycle("TriggerChecker ERROR: Trigger ${trigger.name} in Workflow ${workflow.name} contains dependencies with the same name.");
+        triggerError = true;
+      }
+      triggerDependencyNames.add(triggerDependency.name);
+      // ERROR if dependency config (type + params) is not unique
+      String triggerDependencyConfig = triggerDependency.type + triggerDependency.params.toString();
+      if (triggerDependencyConfig in triggerDependencyConfigs) {
+        project.logger.lifecycle("TriggerChecker ERROR: Trigger ${trigger.name} in Workflow ${workflow.name} contains duplicate dependencies (same type and parameters).");
+        triggerError = true;
+      }
+      triggerDependencyConfigs.add(triggerDependencyConfig);
+      // Check for trigger specific errors
+      if (triggerDependency.type == 'dali-dataset') {
+        triggerError |= checkDaliDatasetDependency((DaliDatasetDependency) triggerDependency);
+      }
+    }
+
+
+    return triggerError;
+  }
+
+  boolean checkWaitMins() {
+    boolean checkWaitMinsError = false;
+
+    // ERROR if maxWaitMins not defined or >1
+    if (trigger.maxWaitMins < MIN_FLOW_TRIGGER_WAIT_TIME) {
+      project.logger.lifecycle("TriggerChecker ERROR: Trigger ${trigger.name} in Workflow ${workflow.name} must define 'maxWaitMins' and it must be greater than 0.");
+      checkWaitMinsError = true;
+    }
+    // WARN if maxWaitMins >10 days (14400 mins)
+    else if (trigger.maxWaitMins > MAX_FLOW_TRIGGER_WAIT_TIME) {
+      project.logger.lifecycle("TriggerChecker WARN: Trigger ${trigger.name} in Workflow ${workflow.name} defines 'maxWaitMins' to be greater than 10 days. Azkaban will automatically reduce to 10 days.");
+    }
+
+    return checkWaitMinsError;
+  }
+
+  boolean checkSchedule() {
+    boolean checkScheduleError = false;
+
+    // ERROR if no schedule defined
+    if (trigger.schedules.isEmpty()) {
+      project.logger.lifecycle("TriggerChecker ERROR: Trigger ${trigger.name} in Workflow ${workflow.name} does not contain a schedule.");
+      checkScheduleError = true;
+    }
+    // ERROR if more than one schedule defined
+    if (trigger.schedules.size() > 1) {
+      project.logger.lifecycle("TriggerChecker ERROR: Trigger ${trigger.name} in Workflow ${workflow.name} contains more than one schedule.");
+      checkScheduleError = true;
+    }
+    // Loop through each schedules (should only be 1) to see if properly defined
+    trigger.schedules.each { Schedule schedule ->
+      // ERROR if no schedule value defined
+      if (schedule.value == null) {
+        project.logger.lifecycle("TriggerChecker ERROR: Schedule ${schedule.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define 'value'.");
+        checkScheduleError = true;
+      }
+      // ERROR if schedule value is not a valid cron expression
+      else if (!CronExpression.isValidExpression(schedule.value)) {
+        project.logger.lifecycle("TriggerChecker ERROR: Schedule ${schedule.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define 'value' as a valid cron expression.");
+        checkScheduleError = true;
+      }
+      // ERROR if schedule value specifies a cron expression that runs more frequently than once per minute
+      else if (schedule.value.split("\\s+")[0] != "0") {
+        project.logger.lifecycle("TriggerChecker ERROR: Schedule ${schedule.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define interval of flow trigger to be larger than 1 minute.");
+        checkScheduleError = true;
+      }
+    }
+
+    return checkScheduleError;
+  }
+
+  boolean checkDaliDatasetDependency(DaliDatasetDependency daliDatasetDependency) {
+    boolean checkDaliDatasetDependencyError = false;
+
+    // ERROR if dali dataset dependency doesn't have a view
+    if (!daliDatasetDependency.params.containsKey("view")) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a view.");
+      checkDaliDatasetDependencyError = true;
+    }
+    // ERROR if dali dataset dependency doesn't have a window
+    if (!daliDatasetDependency.params.containsKey("window")) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a window.");
+      checkDaliDatasetDependencyError = true;
+    }
+    // ERROR if dali dataset dependency doesn't have a delay
+    if (!daliDatasetDependency.params.containsKey("delay")) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a delay.");
+      checkDaliDatasetDependencyError = true;
+    }
+    // ERROR if dali dataset dependency doesn't have a unit
+    if (!daliDatasetDependency.params.containsKey("unit")) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must define a unit.");
+      checkDaliDatasetDependencyError = true;
+    }
+    // ERROR if dali dataset dependency has a window less than one.
+    if (daliDatasetDependency.params["window"] < 1) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must have a window greater than 0.");
+      checkDaliDatasetDependencyError = true;
+    }
+    // ERROR if dali dataset dependency has a window less than one.
+    if (daliDatasetDependency.params["delay"] < 1) {
+      project.logger.lifecycle("TriggerChecker ERROR: DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} must have a nonnegative delay.");
+      checkDaliDatasetDependencyError = true;
+    }
+    // ERROR if dali dataset dependency has a unit that is neither 'daily' nor 'hourly'.
+    String unit = daliDatasetDependency.params["unit"];
+    if (unit != 'daily' && unit != 'hourly') {
+      project.logger.lifecycle("TriggerChecker ERROR: 'unit' value in DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} can only be set to 'daily' or 'hourly'.");
+      checkDaliDatasetDependencyError = true;
+    }
+    // ERROR if dali dataset dependency has an ignoreLocation that is neither 'daily' nor 'hourly'.
+    // if no ignoreLocation set, test passes (ignoreLocation not required
+    String ignoreLocation = daliDatasetDependency.params["ignoreLocation"];
+    if (ignoreLocation != null && ignoreLocation != 'true' && ignoreLocation != 'false') {
+      project.logger.lifecycle("TriggerChecker ERROR: 'ignoreLocation' value in DaliDatasetDependency ${daliDatasetDependency.name} in Trigger ${trigger.name} in Workflow ${workflow.name} can only be set to 'true' or 'false'.");
+      checkDaliDatasetDependencyError = true;
+    }
+
+    return checkDaliDatasetDependencyError;
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/DaliDatasetDependency.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/DaliDatasetDependency.groovy
@@ -1,0 +1,66 @@
+package com.linkedin.gradle.hadoopdsl.triggerDependency;
+
+import com.linkedin.gradle.hadoopdsl.HadoopDslMethod;
+
+// validation?
+//daliDataset('search-impression') {
+//  view 'search_mp_versioned.search_impression_event_0_0_47'
+//  delay 1
+//  window 1
+//  unit 'daily'
+//  filter 'isguest=0'
+//}
+class DaliDatasetDependency extends TriggerDependency {
+  String name;
+  String type;
+  Map params;
+
+  DaliDatasetDependency(String name) {
+    this.name = name;
+    this.type = "dali-dataset";
+    this.params = [:];
+  }
+
+  @HadoopDslMethod
+  void view(String view) {
+    this.params["view"] = view;
+  }
+
+  @HadoopDslMethod
+  void delay(int delay) {
+    this.params["delay"] = delay;
+  }
+
+  @HadoopDslMethod
+  void delay(String delay) {
+    this.params["delay"] = delay.toInteger();
+  }
+
+  @HadoopDslMethod
+  void window(int window) {
+    this.params["window"] = window;
+  }
+
+  @HadoopDslMethod
+  void window(String window) {
+    this.params["window"] = window.toInteger();
+  }
+
+  // TODO validate daily or weekly
+  @HadoopDslMethod
+  void unit(String unit) {
+    this.params["unit"] = unit;
+  }
+
+  // TODO validate true or false
+  @HadoopDslMethod
+  void ignoreLocation(String ignoreLocation) {
+    this.params["ignoreLocation"] = ignoreLocation.toBoolean();
+  }
+
+  // TODO validate true or false
+  @HadoopDslMethod
+  void ignoreLocation(boolean ignoreLocation) {
+    this.params["ignoreLocation"] = ignoreLocation;
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/DaliDatasetDependency.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/DaliDatasetDependency.groovy
@@ -11,12 +11,9 @@ import com.linkedin.gradle.hadoopdsl.HadoopDslMethod;
 //  filter 'isguest=0'
 //}
 class DaliDatasetDependency extends TriggerDependency {
-  String name;
-  String type;
-  Map params;
 
   DaliDatasetDependency(String name) {
-    this.name = name;
+    super(name);
     this.type = "dali-dataset";
     this.params = [:];
   }
@@ -32,18 +29,8 @@ class DaliDatasetDependency extends TriggerDependency {
   }
 
   @HadoopDslMethod
-  void delay(String delay) {
-    this.params["delay"] = delay.toInteger();
-  }
-
-  @HadoopDslMethod
   void window(int window) {
     this.params["window"] = window;
-  }
-
-  @HadoopDslMethod
-  void window(String window) {
-    this.params["window"] = window.toInteger();
   }
 
   // TODO validate daily or weekly
@@ -55,12 +42,6 @@ class DaliDatasetDependency extends TriggerDependency {
   // TODO validate true or false
   @HadoopDslMethod
   void ignoreLocation(String ignoreLocation) {
-    this.params["ignoreLocation"] = ignoreLocation.toBoolean();
-  }
-
-  // TODO validate true or false
-  @HadoopDslMethod
-  void ignoreLocation(boolean ignoreLocation) {
     this.params["ignoreLocation"] = ignoreLocation;
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/DaliDatasetDependency.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/DaliDatasetDependency.groovy
@@ -2,20 +2,14 @@ package com.linkedin.gradle.hadoopdsl.triggerDependency;
 
 import com.linkedin.gradle.hadoopdsl.HadoopDslMethod;
 
-// validation?
-//daliDataset('search-impression') {
-//  view 'search_mp_versioned.search_impression_event_0_0_47'
-//  delay 1
-//  window 1
-//  unit 'daily'
-//  filter 'isguest=0'
-//}
+/**
+ * This dependency is satisfied when the dali dataset view becomes fully available.
+ */
 class DaliDatasetDependency extends TriggerDependency {
 
   DaliDatasetDependency(String name) {
     super(name);
     this.type = "dali-dataset";
-    this.params = [:];
   }
 
   @HadoopDslMethod
@@ -33,13 +27,11 @@ class DaliDatasetDependency extends TriggerDependency {
     this.params["window"] = window;
   }
 
-  // TODO validate daily or weekly
   @HadoopDslMethod
   void unit(String unit) {
     this.params["unit"] = unit;
   }
 
-  // TODO validate true or false
   @HadoopDslMethod
   void ignoreLocation(String ignoreLocation) {
     this.params["ignoreLocation"] = ignoreLocation;

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/DaliDependency.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/DaliDependency.groovy
@@ -5,11 +5,11 @@ import com.linkedin.gradle.hadoopdsl.HadoopDslMethod;
 /**
  * This dependency is satisfied when the dali dataset view becomes fully available.
  */
-class DaliDatasetDependency extends TriggerDependency {
+class DaliDependency extends TriggerDependency {
 
-  DaliDatasetDependency(String name) {
+  DaliDependency(String name) {
     super(name);
-    this.type = "dali-dataset";
+    this.type = "dali";
   }
 
   @HadoopDslMethod
@@ -33,7 +33,7 @@ class DaliDatasetDependency extends TriggerDependency {
   }
 
   @HadoopDslMethod
-  void ignoreLocation(String ignoreLocation) {
+  void ignoreLocation(boolean ignoreLocation) {
     this.params["ignoreLocation"] = ignoreLocation;
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/TriggerDependency.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/TriggerDependency.groovy
@@ -7,5 +7,7 @@ abstract class TriggerDependency {
 
   TriggerDependency(String name) {
     this.name = name;
+    this.type = null;
+    this.params = [:];
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/TriggerDependency.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/TriggerDependency.groovy
@@ -1,0 +1,4 @@
+package com.linkedin.gradle.hadoopdsl.triggerDependency;
+
+abstract class TriggerDependency {
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/TriggerDependency.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/TriggerDependency.groovy
@@ -1,5 +1,8 @@
 package com.linkedin.gradle.hadoopdsl.triggerDependency;
 
+/**
+ * Abstract Trigger Dependency class extended by concrete dependency classes (i.e. DaliDependency).
+ */
 abstract class TriggerDependency {
   String name;
   String type;

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/TriggerDependency.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/triggerDependency/TriggerDependency.groovy
@@ -1,4 +1,11 @@
 package com.linkedin.gradle.hadoopdsl.triggerDependency;
 
 abstract class TriggerDependency {
+  String name;
+  String type;
+  Map params;
+
+  TriggerDependency(String name) {
+    this.name = name;
+  }
 }

--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
@@ -23,7 +23,8 @@ import com.linkedin.gradle.hadoopdsl.Workflow;
 import com.linkedin.gradle.hadoopdsl.job.Job;
 import com.linkedin.gradle.hadoopdsl.job.LaunchJob;
 import com.linkedin.gradle.hadoopdsl.job.StartJob;
-import com.linkedin.gradle.hadoopdsl.job.SubFlowJob;
+import com.linkedin.gradle.hadoopdsl.job.SubFlowJob
+import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDependency;
 import org.gradle.api.Project;
 import org.junit.Before;
 import org.junit.Test;
@@ -284,5 +285,25 @@ class AzkabanDslYamlCompilerTest {
     assertEquals(5, yamlizedTrigger["maxWaitMins"]);
     assertEquals("cron", yamlizedTrigger["schedule"]["type"]);
     assertEquals("0 0 1 ? * *", yamlizedTrigger["schedule"]["value"]);
+  }
+
+  @Test
+  public void TestComplicatedYamlTrigger() {
+    DaliDependency mockDaliDependency = mock(DaliDependency.class);
+    when(mockDaliDependency.name).thenReturn("testDaliDependency");
+    when(mockDaliDependency.type).thenReturn("dali");
+    when(mockDaliDependency.params).thenReturn(["view": "testView", "delay": 1, "window": 2,
+                                                "unit": "hourly", "ignoreLocation": false]);
+    when(mockTrigger.triggerDependencies).thenReturn([mockDaliDependency]);
+
+    Map yamlizedTrigger = yamlCompiler.yamlizeTrigger(mockTrigger);
+    assertEquals(5, yamlizedTrigger["maxWaitMins"]);
+    assertEquals("cron", yamlizedTrigger["schedule"]["type"]);
+    assertEquals("0 0 1 ? * *", yamlizedTrigger["schedule"]["value"]);
+    assertEquals("testView", yamlizedTrigger["triggerDependencies"][0]["params"]["view"]);
+    assertEquals(1, yamlizedTrigger["triggerDependencies"][0]["params"]["delay"]);
+    assertEquals(2, yamlizedTrigger["triggerDependencies"][0]["params"]["window"]);
+    assertEquals("hourly", yamlizedTrigger["triggerDependencies"][0]["params"]["unit"]);
+    assertEquals(false, yamlizedTrigger["triggerDependencies"]["params"][0]["ignoreLocation"]);
   }
 }

--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
@@ -23,7 +23,7 @@ import com.linkedin.gradle.hadoopdsl.Workflow;
 import com.linkedin.gradle.hadoopdsl.job.Job;
 import com.linkedin.gradle.hadoopdsl.job.LaunchJob;
 import com.linkedin.gradle.hadoopdsl.job.StartJob;
-import com.linkedin.gradle.hadoopdsl.job.SubFlowJob
+import com.linkedin.gradle.hadoopdsl.job.SubFlowJob;
 import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDependency;
 import org.gradle.api.Project;
 import org.junit.Before;

--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
@@ -59,6 +59,7 @@ class AzkabanDslYamlCompilerTest {
     when(mockWorkflow.properties).thenReturn([]);
     when(mockWorkflow.jobsToBuild).thenReturn([]);
     when(mockWorkflow.flowsToBuild).thenReturn([]);
+    when(mockWorkflow.triggers).thenReturn([]);
     when(mockWorkflowScope.nextLevel).thenReturn(mockHadoopScope);
 
     when(mockSubflow.name).thenReturn("subflowTest");


### PR DESCRIPTION
As Azkaban rolls out data-availability based triggers, we're updating the DSL so it can generate these triggers.

Note: Since triggers are flow-level, it requires the new Flow 2.0 yaml serialization. You can instruct the DSL to generate yaml by specifying `generateYamlOutput true` in your hadoop closure.

This PR provides a full data triggers implementation. It introduces the Trigger, Schedule, and TriggerDependency objects.
- Trigger objects can be created in any NameScope, but will only be picked up to be output if defined in (or added to) a Workflow. An error will be thrown if more than one Trigger is defined in a Workflow.
- Schedule objects are created inside of Trigger objects and specify the cron value corresponding to when the Trigger will be created in Azkaban. An error will be thrown if more than one schedule is created in a Trigger OR if no schedule is created in a trigger.
- The TriggerDependency abstract object is built to be implemented by many classes so the interface is pluggable. As of this PR there is only one implementation corresponding with the one implementation available in Azkaban when Data Triggers are released - the DaliDependency. Unfortunately, this is a closed-source dependency, so it doesn't offer a great deal of value to the open source community. When the HDFS Dependency is introduced in Azkaban, a corresponding TriggerDependency will also be created here.

Other than the introduction of these objects and the logic to yamlize them in the AzkabanDslYamlCompiler, this PR is primarily checker logic and unit and integration tests. The TriggerChecker is implemented to make sure that Triggers/Schedules/TriggerDependencies are properly defined. The unit tests confirm that the AzkabanDslYamlCompiler compiles the new objects properly. And the integration tests test confirm that the DSL is generating Triggers in Yaml in an expected way and that the TriggerChecker picks up improperly defined Triggers.

More info in #194 