### PR TITLE
Remove unneeded dependency in triggerCheck.gradle

### DIFF
--- a/hadoop-plugin-test/src/main/gradle/negative/triggerCheck.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/triggerCheck.gradle
@@ -6,7 +6,6 @@ buildscript {
     classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
     // Must manually specify snakeyaml and quartz-scheduler for testing, not required for users
     classpath 'org.yaml:snakeyaml:1.18'
-    classpath 'org.quartz-scheduler:quartz:2.2.1'
   }
 }
 


### PR DESCRIPTION
compareKnownOutputFiles test is failing in new test environments (experienced via CRT) because a quartz dependency is being downloaded at this step.

I'm hoping that removing this (unneeded) classpath inclusion will fix it.