### PR TITLE
Adjust cleanBuildOutput to more thoroughly clean output

### DIFF
--- a/hadoop-plugin-test/build.gradle
+++ b/hadoop-plugin-test/build.gradle
@@ -67,7 +67,7 @@ def cleanBuildOutput(String buildOutput) {
   ] as String[]
 
   for (String lineToRemove : linesToRemove) {
-    buildOutput = buildOutput.replaceFirst(lineToRemove, "")
+    buildOutput = buildOutput.replaceAll(lineToRemove, "")
   }
 
   int endIndex = buildOutput.lastIndexOf("Total time:")


### PR DESCRIPTION
In LinkedIn build, the new `triggerCheck` test has two `Download ...` statements.

Because this was `replaceFirst` it only removed the first one, throwing an error for the second. This change should fix this and is more in line with the intent of the method (in my opinion).

Tested locally (manually injecting the `Download ...` statements) and it worked. Will try launching another build to confirm after this is merged.