### PR TITLE
Handling emergent flows for Flow 2.0

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -133,7 +133,7 @@ The following were contributed by Charlie Summers. Thanks, Charlie!
 * `Adding additional condition for TableauJob creation`
 * `Allow generateYamlOutput to be defined multiple times`
 * `Remove maxWaitMins requirement if no dependencies defined in Trigger`
-* `Handling convergent flows for Flow 2.0`
+* `Handling emergent flows for Flow 2.0`
 
 The following were contributed by Nicholas Cowan. Thanks, Nick!
 * `Add ability for Hadoop DSL to understand the HdfsWait job type`

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -133,6 +133,7 @@ The following were contributed by Charlie Summers. Thanks, Charlie!
 * `Adding additional condition for TableauJob creation`
 * `Allow generateYamlOutput to be defined multiple times`
 * `Remove maxWaitMins requirement if no dependencies defined in Trigger`
+* `Handling convergent flows for Flow 2.0`
 
 The following were contributed by Nicholas Cowan. Thanks, Nick!
 * `Add ability for Hadoop DSL to understand the HdfsWait job type`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -18,7 +18,7 @@ Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
 0.14.16
-* Handling convergent flows for Flow 2.0
+* Handling emergent flows for Flow 2.0
 
 0.14.15
 * Remove jdbcDriverClass requirement for SQL job type

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.14.16
+* Handling convergent flows for Flow 2.0
+
 0.14.15
 * Remove jdbcDriverClass requirement for SQL job type
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.14.15
+version=0.14.16

--- a/hadoop-plugin-test/expectedJobs/emergentFlow/emergentFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/emergentFlow/emergentFlow.flow
@@ -1,0 +1,21 @@
+config:
+  flow-level-parameter: value
+nodes:
+- name: emergentFlow
+  type: noop
+  dependsOn:
+  - shellPwd
+  - shellEcho
+  - shellBash
+- name: shellPwd
+  type: command
+  config:
+    command: pwd
+- name: shellEcho
+  type: command
+  config:
+    command: echo "This is an echoed text."
+- name: shellBash
+  type: command
+  config:
+    command: bash ./sample_script.sh

--- a/hadoop-plugin-test/expectedJobs/emergentFlow/hadoop-plugin-test.project
+++ b/hadoop-plugin-test/expectedJobs/emergentFlow/hadoop-plugin-test.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/hadoop-plugin-test/expectedJobs/emergentFlow/otherNamespace/otherNamespace_emergentProperties.tempprops
+++ b/hadoop-plugin-test/expectedJobs/emergentFlow/otherNamespace/otherNamespace_emergentProperties.tempprops
@@ -1,0 +1,2 @@
+new-parameter: new-value
+flow-level-parameter: value2

--- a/hadoop-plugin-test/expectedOutput/positive/emergentFlow.out
+++ b/hadoop-plugin-test/expectedOutput/positive/emergentFlow.out
@@ -1,0 +1,4 @@
+:hadoop-plugin-test:test_emergentFlow
+Running test for the file positive/emergentFlow.gradle
+Hadoop DSL static checker PASSED
+

--- a/hadoop-plugin-test/src/main/gradle/positive/emergentFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/emergentFlow.gradle
@@ -50,19 +50,3 @@ hadoop {
     targets 'shellPwd', 'shellEcho', 'shellBash'
   }
 }
-
-hadoopZip {
-  libPath = "lib"
-  base {
-    from { fileTree("jobs/emergentFlow").exclude("otherNamespace").files } {
-      into "."
-    }
-  }
-  zip("emergentFlowTest") {
-    from { fileTree("jobs/emergentFlow/otherNamespace").files } {
-      into "."
-    }
-  }
-}
-
-startHadoopZips.dependsOn buildAzkabanFlows

--- a/hadoop-plugin-test/src/main/gradle/positive/emergentFlow.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/emergentFlow.gradle
@@ -1,0 +1,68 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Flow for testing yaml creation for emergent flows for Flow 2.0
+
+hadoop {
+  buildPath "jobs/emergentFlow"
+  cleanPath false
+
+  generateYamlOutput true
+
+  namespace('otherNamespace') {
+    propertyFile('emergentProperties') {
+      set properties: [
+              'new-parameter' : 'new-value',
+              'flow-level-parameter' : 'value2'
+      ]
+    }
+  }
+
+  workflow('emergentFlow') {
+    propertyFile('properties') {
+      set properties: [
+              'flow-level-parameter' : 'value'
+      ]
+    }
+
+    commandJob('shellBash') {
+      uses 'bash ./sample_script.sh'
+    }
+
+    commandJob('shellPwd') {
+      uses 'pwd'
+    }
+
+    commandJob('shellEcho') {
+      uses 'echo "This is an echoed text."'
+    }
+
+    targets 'shellPwd', 'shellEcho', 'shellBash'
+  }
+}
+
+hadoopZip {
+  libPath = "lib"
+  base {
+    from { fileTree("jobs/emergentFlow").exclude("otherNamespace").files } {
+      into "."
+    }
+  }
+  zip("emergentFlowTest") {
+    from { fileTree("jobs/emergentFlow/otherNamespace").files } {
+      into "."
+    }
+  }
+}
+
+startHadoopZips.dependsOn buildAzkabanFlows

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslCompiler.groovy
@@ -51,7 +51,8 @@ class AzkabanDslCompiler extends BaseCompiler {
     buildDirectoryFile.eachFileRecurse(groovy.io.FileType.FILES) { f ->
       String fileName = f.getName().toLowerCase();
       if (fileName.endsWith(".job") || fileName.endsWith(".properties") ||
-              fileName.endsWith(".flow") || fileName.endsWith(".project")) {
+              fileName.endsWith(".flow") || fileName.endsWith(".project") ||
+              fileName.endsWith(".tempprops")) {
         f.delete();
       }
     }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -30,10 +30,10 @@ import com.linkedin.gradle.hadoopdsl.job.SubFlowJob;
 import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDependency;
 import com.linkedin.gradle.hadoopdsl.triggerDependency.TriggerDependency;
 import org.gradle.api.Project;
-import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import static com.linkedin.gradle.azkaban.AzkabanConstants.AZK_FLOW_VERSION;
+import static com.linkedin.gradle.util.YamlUtils.setupYamlObject;
 
 /**
  * Translates user-defined workflows, jobs, and properties into <workflow-name>.flow(s) and
@@ -70,7 +70,8 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     buildDirectoryFile.eachFileRecurse(groovy.io.FileType.FILES) { f ->
       String fileName = f.getName().toLowerCase();
       if (fileName.endsWith(".job") || fileName.endsWith(".properties") ||
-              fileName.endsWith(".flow") || fileName.endsWith(".project")) {
+              fileName.endsWith(".flow") || fileName.endsWith(".project") ||
+              fileName.endsWith(".tempprops")) {
         f.delete();
       }
     }
@@ -97,20 +98,16 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
   }
 
   /**
-   * Create and customize a Yaml object.
-   * DumperOptions.FlowStyle.BLOCK indents the yaml in the expected, most readable way.
+   * Instead of visiting workflows and namespaces in the same way the BaseNamedScopeContainer did.
    *
-   * @return new properly setup Yaml object
-   */
-  private static Yaml setupYamlObject() {
-    DumperOptions options = new DumperOptions();
-    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-    return new Yaml(options);
-  }
-
-  /**
-   * Instead of visiting properties, jobs, and propertySets as done in BaseNamedScopeContainer,
-   * only visit workflows and namespaces.
+   * Don't visit jobs, those are visited when workflows are yamlized.
+   *
+   * Don't visit propertySets, those don't need to be visited.
+   *
+   * Only visit properties if there are no workflows present (they are also visited during
+   * yamlization otherwise). This provides backward compatibility with Flow 1.0 by allowing
+   * "emergent flows" to be created by compiling temporary properties files that are merged into
+   * the .flow files during the Zip step.
    *
    * @param container The DSL element subclassing BaseNamedScopeContainer
    */
@@ -130,6 +127,13 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     // Visit each child namespace
     container.namespaces.each { Namespace namespace ->
       visitNamespace(namespace);
+    }
+
+    // Visit properties only if there are no workspaces in the namespace
+    if (container.workflows.isEmpty()) {
+      container.properties.each { Properties properties ->
+        visitProperties(properties)
+      }
     }
 
     // Restore the last parent scope
@@ -183,6 +187,25 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     // Set to read-only to remind people that they should not be editing auto-generated yaml files.
     out.setWritable(false);
     fileWriter.close();
+  }
+
+  /**
+   * This method is only called if there are no workflows in the namespace. It creates a temporary
+   * .tempprops file that will be merged with workflows during the Zip step should it be present.
+   * This allows for Flow 1.0 backward compatibility.
+   *
+   * @param properties Properties whose temp file is to be built
+   */
+  void visitProperties(Properties properties) {
+    Map<String, String> allProperties = properties.buildProperties(this.parentScope);
+    if (allProperties.size() == 0) {
+      return;
+    }
+    String fileName = properties.buildFileName(this.parentScope);
+    File file = new File(this.parentDirectory, "${fileName}.tempprops");
+    FileWriter fileWriter = new FileWriter(file);
+    this.yamlDumper.dump(allProperties, fileWriter)
+    fileWriter.close()
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -98,16 +98,16 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
   }
 
   /**
-   * Instead of visiting workflows and namespaces in the same way the BaseNamedScopeContainer did.
+   * Visit workflows and namespaces in the same way the BaseNamedScopeContainer did.
    *
    * Don't visit jobs, those are visited when workflows are yamlized.
    *
    * Don't visit propertySets, those don't need to be visited.
    *
-   * Only visit properties if there are no workflows present (they are also visited during
-   * yamlization otherwise). This provides backward compatibility with Flow 1.0 by allowing
-   * "emergent flows" to be created by compiling temporary properties files that are merged into
-   * the .flow files during the Zip step.
+   * Only visit properties if there are no workflows present (they are otherwise visited during
+   * yamlization). This provides backward compatibility with Flow 1.0 by allowing "emergent flows"
+   * to be created by compiling temporary properties files that are merged into the .flow files
+   * during the Zip step.
    *
    * @param container The DSL element subclassing BaseNamedScopeContainer
    */
@@ -129,7 +129,7 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
       visitNamespace(namespace);
     }
 
-    // Visit properties only if there are no workspaces in the namespace
+    // Visit properties only if there are no workflows in the namespace
     if (container.workflows.isEmpty()) {
       container.properties.each { Properties properties ->
         visitProperties(properties)

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/util/YamlUtils.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/util/YamlUtils.groovy
@@ -1,0 +1,18 @@
+package com.linkedin.gradle.util
+
+import org.yaml.snakeyaml.DumperOptions
+import org.yaml.snakeyaml.Yaml
+
+class YamlUtils {
+  /**
+   * Create and customize a Yaml object.
+   * DumperOptions.FlowStyle.BLOCK indents the yaml in the expected, most readable way.
+   *
+   * @return new properly setup Yaml object
+   */
+  public static Yaml setupYamlObject() {
+    DumperOptions options = new DumperOptions();
+    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+    return new Yaml(options);
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/zip/HadoopZipExtension.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/zip/HadoopZipExtension.groovy
@@ -245,7 +245,8 @@ class HadoopZipExtension {
           String newFlowFile = YamlMerge.merge(file, tempPropsList, zipName);
           newFlowFilePathsList.add(newFlowFile);
         }
-        else if (flowFile.matches(/.*_.*/) && !flowFile.matches(/.*${zipName}.*/)) {
+        else if (flowFile.matches(/.*_.*/) && flowFile.matches(/.*\.flow/) &&
+                !flowFile.matches(/.*${zipName}.*/)) {
           // Remove all flow files with underscores that do not have the zipName included
           // These are merged flow files from another namespace
           flowFilePathsList.add(flowFile);

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/zip/HadoopZipExtension.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/zip/HadoopZipExtension.groovy
@@ -18,6 +18,7 @@ package com.linkedin.gradle.zip;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.bundling.Zip;
 
@@ -163,7 +164,7 @@ class HadoopZipExtension {
    * @return The zip task
    */
   Task createZipTask(Project project, String zipName) {
-    return project.tasks.create(name: "${zipName}HadoopZip", type: Zip) { task ->
+    return project.tasks.create(name: "${zipName}HadoopZip", type: Zip) { Task task ->
       classifier = zipName.equals("main") ? "" : zipName;
       description = "Creates a Hadoop zip archive for ${zipName}";
       group = "Hadoop Plugin";
@@ -171,6 +172,10 @@ class HadoopZipExtension {
       // This task is a dependency of buildHadoopZips and depends on the startHadoopZips
       project.tasks["buildHadoopZips"].dependsOn task;
       dependsOn "startHadoopZips";
+
+      doFirst {
+        mergeTempPropsWithFlowFiles(task, zipName);
+      }
 
       // Include files specified by the user through hadoopZip extension. If there is a base
       // CopySpec, add it as a child of the zip-specific CopySpec.
@@ -201,6 +206,55 @@ class HadoopZipExtension {
       doLast {
         project.logger.lifecycle("Prepared archive for Hadoop zip '${zipName}' at: ${archivePath}");
       }
+    }
+  }
+
+  /**
+   * This enables "Emergent Flows" in Flow 2.0 - so users can define properties in a separate
+   * namespace then merge them into the resulting yaml workflows at Zip time.
+   *
+   * This method retrieves all .tempprops source files in the task and turns them into Maps, then
+   * merges those maps into the root level config of all of the .flow file (to ensure backward
+   * compatibility). The resulting object is then saved in a new .flow file.
+   *
+   * @param task Task where merging may occur
+   * @param zipName Name of the zip being generated - used to create new .flow file names
+   */
+  void mergeTempPropsWithFlowFiles(Task task, String zipName) {
+    List<Map<String, String>> tempPropsList = [];
+    List<String> tempPropsPathsList = [];
+    List<String> flowFilePathsList = [];
+    List<String> newFlowFilePathsList = [];
+
+    task.source.visit { FileVisitDetails tempProps ->
+      String tempPropsPath = tempProps.path;
+      if (tempPropsPath.matches(/.*\.tempprops/)) {
+        Map<String, String> tempPropsMap = YamlMerge.readInYaml(tempProps);
+        tempPropsList.add(tempPropsMap);
+        tempPropsPathsList.add(tempPropsPath);
+      }
+    }
+    // Merge all .tempprops files into the .flow files and create new .flow files with the results
+    if (!tempPropsList.isEmpty()) {
+      task.source.visit { FileVisitDetails file ->
+        String flowFile = file.path;
+        if (flowFile.matches(/.*\.flow/) && !flowFile.matches(/.*_.*/)) {
+          // Consider all .flow files to be flows except for those that have underscores
+          // Those that have underscores are files that were already merged
+          flowFilePathsList.add(flowFile);
+          String newFlowFile = YamlMerge.merge(file, tempPropsList, zipName);
+          newFlowFilePathsList.add(newFlowFile);
+        }
+        else if (flowFile.matches(/.*_.*/) && !flowFile.matches(/.*${zipName}.*/)) {
+          // Remove all flow files with underscores that do not have the zipName included
+          // These are merged flow files from another namespace
+          flowFilePathsList.add(flowFile);
+        }
+      }
+      // Remove all .tempprops files and old .flow files from the zip and include the new .flow files
+      task.exclude tempPropsPathsList;
+      task.exclude flowFilePathsList;
+      newFlowFilePathsList.each { String path -> task.from(path); }
     }
   }
 

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/zip/YamlMerge.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/zip/YamlMerge.groovy
@@ -1,0 +1,62 @@
+package com.linkedin.gradle.zip
+
+import org.gradle.api.file.FileVisitDetails;
+import org.yaml.snakeyaml.Yaml;
+
+import static com.linkedin.gradle.util.YamlUtils.setupYamlObject;
+
+/**
+ * YamlMerge is used to combine .tempprops files and .flow files. This is necessary to provide
+ * backward compatibility with Flow 1.0 in Flow 2.0.
+ */
+class YamlMerge {
+  // Yaml object used to read in/write out yaml files.
+  static Yaml yamlWorker = setupYamlObject();
+
+  /**
+   * Takes in the file path of a .flow file and a list of properties from .tempprops files and
+   * merges them.
+   *
+   * Merging involves taking all the properties defined in the .tempprops files and adding them
+   * to the top level workflow config in the .flow file. This definition of merging enables
+   * backward compatibility with Flow 1.0.
+   *
+   * @param flowFilePath Path to .flow that will receive the additional properties
+   * @param tempPropsPathsList List of paths to .tempprops files
+   * @param zipName The name of the zip to be generated - used to create the new .flow filename
+   * @return String The name of the created file to be added to the task's sources
+   */
+  static String merge(FileVisitDetails flowFile, List<Map<String, String>> tempPropsList,
+                      String zipName) {
+    Map flow = readInYaml(flowFile);
+    if (!flow.containsKey("config")) {
+      flow.put("config", [:]);
+    }
+    tempPropsList.each { tempProps ->
+      tempProps.each { tempPropsKey, tempPropsVal ->
+        flow["config"][tempPropsKey] = tempPropsVal;
+      }
+    }
+    String newFlowFileName = flowFile.name.replace(".flow", "_${zipName}.flow");
+    File file = new File(flowFile.file.getParentFile(), newFlowFileName);
+    FileWriter fileWriter = new FileWriter(file);
+    yamlWorker.dump(flow, fileWriter);
+    // Set to read-only to remind people that they should not be editing auto-generated yaml files.
+    file.setWritable(false);
+    fileWriter.close();
+    return newFlowFileName;
+  }
+
+  /**
+   * Takes in a yaml file that's assumed to be a Map at the root level and returning it.
+   *
+   * @param file Yaml file assumed to be a Map at the root level
+   * @return Map pulled from the Yaml file
+   */
+  static Map readInYaml(FileVisitDetails file) {
+    InputStream fileInputStream = file.open();
+    Map loadedMap = (Map) yamlWorker.load(fileInputStream);
+    fileInputStream.close();
+    return loadedMap;
+  }
+}


### PR DESCRIPTION
In Flow 1.0, we had an interesting property (called emergent flows) where users could write .properties files to a separate directory than the original workflow directory during compile time, then include them both at zip time to create the workflow that is ultimately uploaded. This was nice because you could specify multiple zip files and pick different properties for each zip file in order to have different properties on different clusters. This was a heavily used mechanism for having cluster-specific properties at LinkedIn.

For Flow 2.0 this is less straightforward because the Yaml object is completely generated at compile time. So this PR introduces a similar mechanism to allow properties to be merged into flows at zip time.

The way it works is like this:

If a namespace has NO workflows defined but DOES have properties defined, it writes those properties to a .tempprops file. Properties defined with workflows are expected to be workflow properties.

At zip time, if the zip contains any .tempprops files, it reads them in then reads in all the .flow files and merges them together. It then creates new .flow files with the resulting properties included. The files are named <original-flow-name>_<zip-name>.flow so each zip will create a uniquely named .flow file. The original .flow files and .tempprops files are then not included in the zip while the new .flow files are.

This should create backward compatibility with Flow 1.0 for flows that leverage the emergent flows property.