### PR TITLE
Bump version to match li-hadoop-plugin MP.

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.14.26
+* Bump version to match li-hadoop-plugin MP
+
 0.14.17
 * Add conditional workflow feature
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.14.17
+version=0.14.26


### PR DESCRIPTION
> You MUST sync the product-spec version with the Hadoop Plugin version number (as given in its gradle.properties file). We used to have scripts that would sync these automatically, but they no longer work with the most recent versions of ligradle.
> 
> You can either bump the product-spec version to match the Hadoop Plugin version, or vice-versa (you generally want to set them both to whichever has the latest version number). If you don't do this, you will get an error during PCX.
> 
> The error occurs when PCX is about to publish the artifacts to Artifactory, but notices that the declared product-spec version doesn't match the version of the artifacts.