### PR TITLE
Fix base properties scope for subflows when generating YAML files.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -154,3 +154,4 @@ The following were contributed by Chris Li.
 
 The following were contributed by Jamie Sun. Thanks, Jamie! 
 * `Add conditional workflow feature`
+* `Fix base properties scope for subflows when generating YAML files`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.14.27
+* Fix base properties scope for subflows when generating YAML files
+
 0.14.26
 * Bump version to match li-hadoop-plugin MP
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.14.26
+version=0.14.27

--- a/hadoop-plugin-test/expectedJobs/embeddedFlowWithBaseProperties/embeddedFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/embeddedFlowWithBaseProperties/embeddedFlow.flow
@@ -1,0 +1,17 @@
+nodes:
+- name: embeddedFlow
+  type: noop
+  dependsOn:
+  - embeddedFlow1
+- name: embeddedFlow1
+  type: flow
+  nodes:
+  - name: embeddedFlow1
+    type: noop
+    dependsOn:
+    - shellEcho
+  - name: shellEcho
+    type: command
+    config:
+      command: echo "This is an echoed text from embeddedFlow1."
+      user.to.proxy: foo

--- a/hadoop-plugin-test/expectedJobs/embeddedFlowWithBaseProperties/hadoop-plugin-test.project
+++ b/hadoop-plugin-test/expectedJobs/embeddedFlowWithBaseProperties/hadoop-plugin-test.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/hadoop-plugin-test/expectedOutput/positive/embeddedFlowWithBaseProperties.out
+++ b/hadoop-plugin-test/expectedOutput/positive/embeddedFlowWithBaseProperties.out
@@ -1,0 +1,4 @@
+:hadoop-plugin-test:test_embeddedFlowWithBaseProperties
+Running test for the file positive/embeddedFlowWithBaseProperties.gradle
+Hadoop DSL static checker PASSED
+

--- a/hadoop-plugin-test/src/main/gradle/positive/embeddedFlowWithBaseProperties.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/embeddedFlowWithBaseProperties.gradle
@@ -1,0 +1,37 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Test an embedded flow with base properties set in the job for Flow 2.0
+
+hadoop {
+  buildPath "jobs/embeddedFlowWithBaseProperties"
+  cleanPath false
+
+  generateYamlOutput true
+
+  workflow('embeddedFlow') {
+    propertySet('common') {
+      set properties: ['user.to.proxy' : 'foo']
+    }
+
+    workflow('embeddedFlow1') {
+      commandJob('shellEcho') {
+        baseProperties 'common'
+        uses 'echo "This is an echoed text from embeddedFlow1."'
+      }
+      targets 'shellEcho'
+    }
+
+    targets 'embeddedFlow1'
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -234,6 +234,14 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
    * @return Map representing workflow to be output in yaml file.
    */
   Map yamlizeWorkflow(Workflow workflow, boolean isSubflow) {
+    // Save the last scope information
+    NamedScope oldParentScope = this.parentScope;
+    String oldParentDirectory = this.parentDirectory;
+
+    // Set the new parent scope information
+    this.parentScope = workflow.scope;
+    this.parentDirectory = "${this.parentDirectory}/${workflow.name}";
+
     Map yamlizedWorkflow = [:];
 
     // Add workflow name if subflow
@@ -265,6 +273,10 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     if (!nodes.isEmpty()) {
       yamlizedWorkflow["nodes"] = nodes;
     }
+
+    // Restore the last parent scope
+    this.parentScope = oldParentScope;
+    this.parentDirectory = oldParentDirectory;
 
     return yamlizedWorkflow;
   }


### PR DESCRIPTION
The issue happens when defining baseProperties for jobs inside subflows when generating YAML files. For example, in workflow.gradle:

```
hadoop {
  buildPath "jobs/embeddedFlowWithBaseProperties"
  cleanPath false
  generateYamlOutput true

  workflow('embeddedFlow') {
    propertySet('common') {
      set properties: ['user.to.proxy' : 'foo']
    }

    workflow('embeddedFlow1') {
      commandJob('shellEcho') {
        baseProperties 'common'
        uses 'echo "This is an echoed text from embeddedFlow1."'
      }
      targets 'shellEcho'
    }

    targets 'embeddedFlow1'
  }
}
```

This would throw below exception:

```
Caused by: java.lang.NullPointerException: Cannot invoke method fillProperties() on null object
        at com.linkedin.gradle.hadoopdsl.job.Job.buildProperties(Job.groovy:161)
        at com.linkedin.gradle.hadoopdsl.job.CommandJob.super$2$buildProperties(CommandJob.groovy)
        at com.linkedin.gradle.hadoopdsl.job.CommandJob.buildProperties(CommandJob.groovy:59)
        at com.linkedin.gradle.hadoopdsl.job.CommandJob$buildProperties.call(Unknown Source)
        at com.linkedin.gradle.hadoopdsl.job.Job$buildProperties$0.call(Unknown Source)
        at com.linkedin.gradle.azkaban.AzkabanDslYamlCompiler.yamlizeJob(AzkabanDslYamlCompiler.groovy:305)
```

The issue was caused by the incorrect parent scope of subflows when recursively yamlizing the subflow. The scope needs to be updated during the recursion.