### PR TITLE
fix variable substitution issue when generating YAML files.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -155,3 +155,4 @@ The following were contributed by Chris Li.
 The following were contributed by Jamie Sun. Thanks, Jamie! 
 * `Add conditional workflow feature`
 * `Fix base properties scope for subflows when generating YAML files`
+* `Fix variable substitution issue when generating YAML files`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.14.28
+* Fix variable substitution issue when generating YAML files
+
 0.14.27
 * Fix base properties scope for subflows when generating YAML files
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.14.27
+version=0.14.28

--- a/hadoop-plugin-test/expectedJobs/flowWithVariableSubstitution/hadoop-plugin-test.project
+++ b/hadoop-plugin-test/expectedJobs/flowWithVariableSubstitution/hadoop-plugin-test.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/hadoop-plugin-test/expectedJobs/flowWithVariableSubstitution/wordCountFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/flowWithVariableSubstitution/wordCountFlow.flow
@@ -1,0 +1,30 @@
+config:
+  user.to.proxy: foo
+nodes:
+- name: wordCountFlow
+  type: noop
+  dependsOn:
+  - checkResultsJob
+- name: checkResultsJob
+  type: hadoopShell
+  dependsOn:
+  - wordCountMapReduceJob
+  config:
+    command: bash ./bash/checkResults.sh . Government
+- name: wordCountMapReduceJob
+  type: hadoopJava
+  dependsOn:
+  - uploadResourceFilesJob
+  condition: ${uploadResourceFilesJob:param1} == "foo"
+  config:
+    job.class: com.linkedin.hadoop.example.WordCountJob
+    classpath: ./lib/*
+    input.path: ./text
+    output.path: ./word-count-map-reduce
+    hadoop-inject.mapreduce.job.classloader: 'true'
+    force.output.overwrite: 'true'
+- name: uploadResourceFilesJob
+  type: hadoopShell
+  config:
+    command: hadoop fs -mkdir -p .
+    command.1: hadoop fs -copyFromLocal -f ./text .

--- a/hadoop-plugin-test/expectedOutput/positive/flowWithVariableSubstitution.out
+++ b/hadoop-plugin-test/expectedOutput/positive/flowWithVariableSubstitution.out
@@ -1,0 +1,4 @@
+:hadoop-plugin-test:test_flowWithVariableSubstitution
+Running test for the file positive/flowWithVariableSubstitution.gradle
+Hadoop DSL static checker PASSED
+

--- a/hadoop-plugin-test/src/main/gradle/positive/flowWithVariableSubstitution.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/flowWithVariableSubstitution.gradle
@@ -1,0 +1,66 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Test generating a flow YAML file with variable substitution "${}" in the job properties, job name, dependencies and conditions
+
+def projectPath = "."
+def jobName = "uploadResourceFilesJob"
+
+hadoop {
+  buildPath "jobs/flowWithVariableSubstitution"
+  cleanPath true
+  generateYamlOutput true
+
+  propertyFile('common') {
+    set properties: [
+      'user.to.proxy': 'foo'
+    ]
+  }
+
+  workflow('wordCountFlow') {
+    hadoopShellJob("${jobName}") {
+      usesCommands([
+          "hadoop fs -mkdir -p ${projectPath}",
+          "hadoop fs -copyFromLocal -f ./text ${projectPath}"
+      ])
+    }
+
+    hadoopJavaJob('wordCountMapReduceJob') {
+      uses 'com.linkedin.hadoop.example.WordCountJob'
+      jvmClasspath './lib/*'
+      reads files: [
+          'input.path': "${projectPath}/text"
+      ]
+      writes files: [
+          'output.path': "${projectPath}/word-count-map-reduce"
+      ]
+      set confProperties: [
+          'mapreduce.job.classloader': true
+      ]
+      set properties: [
+          'force.output.overwrite': true
+      ]
+      depends "${jobName}"
+      conditions '${' + "${jobName}" + ':param1} == "foo"'
+    }
+
+    def keywordToCheck = "Government"
+
+    hadoopShellJob('checkResultsJob') {
+      uses "bash ./bash/checkResults.sh ${projectPath} ${keywordToCheck}"
+      depends 'wordCountMapReduceJob'
+    }
+
+    targets 'checkResultsJob'
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -307,6 +307,11 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     config.remove("type");
     config.remove("dependencies");
     if (!config.isEmpty()) {
+      // If the job config contains "${}", which is a GString, it can involve lazy evaluation.
+      // It means it's not until the toString() method is invoked that the GString is evaluated.
+      // Without toString(), it can cause incompatible issue when writing the GString directly
+      // to YAML file.
+      config.each { key, val -> config[key] = val.toString()};
       yamlizedJob["config"] = config;
     }
 

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanDslYamlCompiler.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanDslYamlCompiler.groovy
@@ -68,7 +68,7 @@ class LiAzkabanDslYamlCompiler extends AzkabanDslYamlCompiler {
     writeGradleForBangBangJob(job, this.project, this.parentScope, this.parentDirectory);
     List<String> filteredKeys = addBangBangProperties(config);
     filteredKeys.each { key ->
-      filteredConfig[key] = config[key];
+      filteredConfig[key] = config[key].toString();
     }
     if (!filteredConfig.isEmpty()) {
       yamlizedJob["config"] = filteredConfig;


### PR DESCRIPTION
When adding `generateYamlOutput true` in the workflow gradle file, the YAML file could not be generated correctly for the hadoopShell job which contains variable substitution `"${}" `in the `usesCommands`. When uploading the project zip, it failed because `!!` was a special character for tags in snakeYaml.
```
 config:
      command: !!org.codehaus.groovy.runtime.GStringImpl
        metaClass: &id001 !!groovy.lang.MetaClassImpl {}
      command.1: !!org.codehaus.groovy.runtime.GStringImpl
        metaClass: *id001
```
Did some research and found out the root cause:
If the job config contains `${}`, which is a GString, it can involve lazy evaluation. It means it's not until the `toString()` method is invoked that the GString is evaluated. Without `toString()`, it can cause the incompatible issue when writing the GString directly to YAML file. 
In CommandJob or HadoopShellJob which extends CommandJob, when calling `com.linkedin.gradle.hadoopdsl.job.CommandJob#buildProperties`
, it will not invoke `toString()` method for `command` properties. So it failed when writing to YAML file. There could be other job types that are having the same issue. And the proposed fix applied to all job types.

Reference: https://stackoverflow.com/questions/18975465/groovy-gstringimpl-and-string-behaviour
