### PR TITLE
Fix variable substitution issue for dependency list.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -156,3 +156,4 @@ The following were contributed by Jamie Sun. Thanks, Jamie!
 * `Add conditional workflow feature`
 * `Fix base properties scope for subflows when generating YAML files`
 * `Fix variable substitution issue when generating YAML files`
+* `Fix variable substitution issue for dependency list`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.14.29
+* Fix variable substitution issue for dependency list
+
 0.14.28
 * Fix variable substitution issue when generating YAML files
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.14.28
+version=0.14.29

--- a/hadoop-plugin-test/src/main/gradle/positive/flowWithVariableSubstitution.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/flowWithVariableSubstitution.gradle
@@ -15,6 +15,9 @@ apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
 
 def projectPath = "."
 def jobName = "uploadResourceFilesJob"
+def jobName2 = "checkResultsJob"
+def dependList = ["${jobName}"]
+def targetList = ["${jobName2}"]
 
 hadoop {
   buildPath "jobs/flowWithVariableSubstitution"
@@ -50,17 +53,17 @@ hadoop {
       set properties: [
           'force.output.overwrite': true
       ]
-      depends "${jobName}"
+      depends dependList
       conditions '${' + "${jobName}" + ':param1} == "foo"'
     }
 
     def keywordToCheck = "Government"
 
-    hadoopShellJob('checkResultsJob') {
+    hadoopShellJob("${jobName2}") {
       uses "bash ./bash/checkResults.sh ${projectPath} ${keywordToCheck}"
       depends 'wordCountMapReduceJob'
     }
 
-    targets 'checkResultsJob'
+    targets targetList
   }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -296,7 +296,7 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     yamlizedJob["type"] = job.jobProperties["type"];
     // Add job dependencies if there are any
     if (!job.dependencyNames.isEmpty()) {
-      yamlizedJob["dependsOn"] = job.dependencyNames.toList();
+      yamlizedJob["dependsOn"] = job.dependencyNames.toList().collect{ dep -> dep.toString() };
     }
     if(job.condition != null) {
       yamlizedJob["condition"] = job.condition;


### PR DESCRIPTION
Similar to the issue in #228 , it will cause an incompatible issue when defining `depends` or `targets` as a list which contains `${}` when generating YAML files.
For example, in workflow.gradle:
```
def jobName = "job1"
def targetList = ["${jobName}"]
hadoop {
  workflow('wordCountFlow') {
    hadoopShellJob("${jobName}") {
      uses "bash ./test.sh"
    }
    targets targetList
  }
}
```
This would throw below error:
```
- name: wordCountFlow
  type: noop
  dependsOn:
  - !!org.codehaus.groovy.runtime.GStringImpl
    metaClass: &id001 !!groovy.lang.MetaClassImpl {}
```
We should also explicitly do the `toString() `conversion for the dependency list.
