### PR TITLE
Fix cloneWorkflow and cloneJob issue for conditional workflow

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -157,6 +157,7 @@ The following were contributed by Jamie Sun. Thanks, Jamie!
 * `Fix base properties scope for subflows when generating YAML files`
 * `Fix variable substitution issue when generating YAML files`
 * `Fix variable substitution issue for dependency list`
+* `Fix cloneWorkflow and cloneJob issue when generating conditional workflows`
 
 The following were contributed by Rakesh Malladi. Thanks, Rakesh!
 * `Add ability for Hadoop DSL to understand the WormholePushJob job type`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.14.31
+* Fix cloneWorkflow and cloneJob issue when generating conditional workflows
+
 0.14.30
 * Adding WormholePushJob job type support
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.14.30
+version=0.14.31

--- a/hadoop-plugin-test/expectedJobs/cloneJobWithCondition/hadoop-plugin-test.project
+++ b/hadoop-plugin-test/expectedJobs/cloneJobWithCondition/hadoop-plugin-test.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/hadoop-plugin-test/expectedJobs/cloneJobWithCondition/workflow1.flow
+++ b/hadoop-plugin-test/expectedJobs/cloneJobWithCondition/workflow1.flow
@@ -1,0 +1,31 @@
+nodes:
+- name: workflow1
+  type: noop
+  dependsOn:
+  - shellEcho
+  - embeddedFlow
+- name: shellEcho
+  type: command
+  dependsOn:
+  - shellPwd
+  condition: one_success
+  config:
+    command: echo "This is an echoed text."
+- name: shellPwd
+  type: command
+  config:
+    command: pwd
+- name: embeddedFlow
+  type: flow
+  dependsOn:
+  - shellPwd
+  condition: one_failed
+  nodes:
+  - name: embeddedFlow
+    type: noop
+    dependsOn:
+    - job1
+  - name: job1
+    type: command
+    config:
+      command: pwd

--- a/hadoop-plugin-test/expectedOutput/positive/cloneJobWithCondition.out
+++ b/hadoop-plugin-test/expectedOutput/positive/cloneJobWithCondition.out
@@ -1,0 +1,4 @@
+:hadoop-plugin-test:test_cloneJobWithCondition
+Running test for the file positive/cloneJobWithCondition.gradle
+Hadoop DSL static checker PASSED
+

--- a/hadoop-plugin-test/src/main/gradle/positive/cloneJobWithCondition.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/cloneJobWithCondition.gradle
@@ -1,0 +1,47 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Test clone a workflow (which invokes clone jobs) when generating conditional workflows
+
+workflow('basicFlow') {
+  commandJob('shellPwd') {
+    uses 'pwd'
+  }
+
+  commandJob('shellEcho') {
+    uses 'echo "This is an echoed text."'
+    depends 'shellPwd'
+    conditions 'one_success'
+  }
+
+  workflow('embeddedFlow') {
+    commandJob('job1') {
+      uses 'pwd'
+    }
+
+    flowDepends('shellPwd')
+    conditions 'one_failed'
+    targets 'job1'
+  }
+
+  targets 'shellEcho', 'embeddedFlow'
+}
+
+hadoop {
+  buildPath "jobs/cloneJobWithCondition"
+  cleanPath false
+
+  generateYamlOutput true
+
+  addWorkflow('basicFlow', 'workflow1') {}
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Workflow.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/Workflow.groovy
@@ -273,6 +273,7 @@ class Workflow extends BaseNamedScopeContainer {
    */
   protected Workflow clone(Workflow workflow) {
     workflow.isGrouping = isGrouping;
+    workflow.condition = condition;
     workflow.launchDependencies.addAll(launchDependencies);
     workflow.parentDependencies.addAll(parentDependencies);
     return ((Workflow)super.clone(workflow));

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/Job.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/Job.groovy
@@ -201,6 +201,7 @@ class Job {
    */
   Job clone(Job cloneJob) {
     cloneJob.basePropertySetName = basePropertySetName;
+    cloneJob.condition = condition;
     cloneJob.dependencyNames.addAll(dependencyNames);
     cloneJob.jobProperties.putAll(jobProperties);
     cloneJob.reading.putAll(reading);


### PR DESCRIPTION
When cloning a workflow or a job, the condition should also be cloned.