### PR TITLE
Fix variable substitution issue for flow dependency list.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -158,6 +158,7 @@ The following were contributed by Jamie Sun. Thanks, Jamie!
 * `Fix variable substitution issue when generating YAML files`
 * `Fix variable substitution issue for dependency list`
 * `Fix cloneWorkflow and cloneJob issue when generating conditional workflows`
+* `Fix variable substitution issue for flow dependency list`
 
 The following were contributed by Rakesh Malladi. Thanks, Rakesh!
 * `Add ability for Hadoop DSL to understand the WormholePushJob job type`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.14.32
+* Fix variable substitution issue for flow dependency list
+
 0.14.31
 * Fix cloneWorkflow and cloneJob issue when generating conditional workflows
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.14.31
+version=0.14.32

--- a/hadoop-plugin-test/expectedJobs/flowWithVariableSubstitution/wordCountFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/flowWithVariableSubstitution/wordCountFlow.flow
@@ -9,6 +9,7 @@ nodes:
   type: hadoopShell
   dependsOn:
   - wordCountMapReduceJob
+  - embeddedFlow
   config:
     command: bash ./bash/checkResults.sh . Government
 - name: wordCountMapReduceJob
@@ -28,3 +29,16 @@ nodes:
   config:
     command: hadoop fs -mkdir -p .
     command.1: hadoop fs -copyFromLocal -f ./text .
+- name: embeddedFlow
+  type: flow
+  dependsOn:
+  - uploadResourceFilesJob
+  nodes:
+  - name: embeddedFlow
+    type: noop
+    dependsOn:
+    - job1
+  - name: job1
+    type: command
+    config:
+      command: pwd

--- a/hadoop-plugin-test/src/main/gradle/positive/flowWithVariableSubstitution.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/flowWithVariableSubstitution.gradle
@@ -18,6 +18,7 @@ def jobName = "uploadResourceFilesJob"
 def jobName2 = "checkResultsJob"
 def dependList = ["${jobName}"]
 def targetList = ["${jobName2}"]
+def flowDependList = ["${jobName}"]
 
 hadoop {
   buildPath "jobs/flowWithVariableSubstitution"
@@ -57,11 +58,19 @@ hadoop {
       conditions '${' + "${jobName}" + ':param1} == "foo"'
     }
 
+    workflow("embeddedFlow") {
+      commandJob("job1") {
+        uses 'pwd'
+      }
+      flowDepends clear: 'false', targetNames: flowDependList
+      targets 'job1'
+    }
+
     def keywordToCheck = "Government"
 
     hadoopShellJob("${jobName2}") {
       uses "bash ./bash/checkResults.sh ${projectPath} ${keywordToCheck}"
-      depends 'wordCountMapReduceJob'
+      depends 'wordCountMapReduceJob', 'embeddedFlow'
     }
 
     targets targetList

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -258,7 +258,7 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     }
     // Add dependencies if there are any
     if (!workflow.parentDependencies.isEmpty()) {
-      yamlizedWorkflow["dependsOn"] = workflow.parentDependencies.toList();
+      yamlizedWorkflow["dependsOn"] = workflow.parentDependencies.toList().collect{ dep -> dep.toString() };
     }
     if(isSubflow && workflow.condition != null) {
       yamlizedWorkflow["condition"] = workflow.condition;


### PR DESCRIPTION
Saw a similar issue  #229 when users define variable substitution in the flow dependency list.
For example, below would fail with some yaml GString exception:
```
def jobName = "uploadResourceFilesJob"
flowDepends clear: 'false', targetNames: ["${jobName}"]
```