### PR TITLE
Always log response from Azkaban during upload

### DIFF
--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanUploadTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanUploadTask.groovy
@@ -160,15 +160,15 @@ class AzkabanUploadTask extends DefaultTask {
       httpClient.getConnectionManager().getSchemeRegistry().register(scheme);
       HttpResponse response = httpClient.execute(httpPost);
 
-      if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-        throw new GradleException("Upload task failed.\nStatus line: " + response.getStatusLine().toString() + "\nStatus code: " + response.getStatusLine().getStatusCode() + "\nAlternately, you can upload the zip to your project via Azkaban UI.");
-      }
-
       logger.lifecycle("\n--------------------------------------------------------------------------------");
       logger.lifecycle(AzkabanHelper.parseResponse(response.toString()));
       String result = AzkabanHelper.parseContent(response.getEntity().getContent());
       logger.lifecycle(result);
       logger.lifecycle("--------------------------------------------------------------------------------");
+
+      if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+        throw new GradleException("Upload task failed.\nStatus line: " + response.getStatusLine().toString() + "\nStatus code: " + response.getStatusLine().getStatusCode() + "\nAlternately, you can upload the zip to your project via Azkaban UI.");
+      }
 
       // Check if there was an error during the upload.
       JSONObject jsonObj = new JSONObject(result);


### PR DESCRIPTION
We currently only log the response from Azkaban when it's a 200 status code, which makes it hard to troubleshoot what went wrong when it's a non-200 status (we just print the status line and the response code). This moves the logging of the response above where we check if it was an error so that it's printed regardless.