### PR TITLE
Stop outputting max wait mins when it's defined in a flow trigger with no dependencies

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.14.35
+* Stop outputting max wait mins when it's defined in a flow trigger with no dependencies
+
 0.14.34
 * Deprecate dataset.group property from the WormholePushJob
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.14.34
+version=0.14.35

--- a/hadoop-plugin-test/expectedJobs/triggerFlowWithoutDep/hadoop-plugin-test.project
+++ b/hadoop-plugin-test/expectedJobs/triggerFlowWithoutDep/hadoop-plugin-test.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/hadoop-plugin-test/expectedJobs/triggerFlowWithoutDep/triggerFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/triggerFlowWithoutDep/triggerFlow.flow
@@ -1,0 +1,25 @@
+trigger:
+  schedule:
+    type: cron
+    value: 0 0 1 ? * *
+config:
+  flow-level-parameter: value
+nodes:
+- name: triggerFlow
+  type: noop
+  dependsOn:
+  - shellPwd
+  - shellEcho
+  - shellBash
+- name: shellPwd
+  type: command
+  config:
+    command: pwd
+- name: shellEcho
+  type: command
+  config:
+    command: echo "This is an echoed text."
+- name: shellBash
+  type: command
+  config:
+    command: bash ./sample_script.sh

--- a/hadoop-plugin-test/expectedOutput/positive/triggerFlowWithoutDep.out
+++ b/hadoop-plugin-test/expectedOutput/positive/triggerFlowWithoutDep.out
@@ -1,0 +1,4 @@
+:hadoop-plugin-test:test_triggerFlowWithoutDep
+Running test for the file positive/triggerFlowWithoutDep.gradle
+Hadoop DSL static checker PASSED
+

--- a/hadoop-plugin-test/src/main/gradle/positive/triggerFlowWithoutDep.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/triggerFlowWithoutDep.gradle
@@ -1,0 +1,50 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath files("${project.pluginTestDir}/hadoop-plugin-${project.version}.jar", "${project.pluginTestDir}/hadoop-plugin-${project.version}-SNAPSHOT.jar")
+    // Must manually specify snakeyaml and quartz-scheduler for testing, not required for users
+    classpath 'org.yaml:snakeyaml:1.18'
+    classpath 'org.quartz-scheduler:quartz:2.2.1'
+  }
+}
+
+apply plugin: com.linkedin.gradle.hadoop.HadoopPlugin
+
+// Simple flow for testing trigger creation
+
+hadoop {
+  buildPath "jobs/triggerFlowWithoutDep"
+  cleanPath false
+
+  generateYamlOutput true
+
+  workflow('triggerFlow') {
+    trigger('trigger') {
+      schedule {
+        value '0 0 1 ? * *'
+      }
+    }
+
+    propertyFile('properties') {
+      set properties: [
+              'flow-level-parameter' : 'value'
+      ]
+    }
+
+    commandJob('shellBash') {
+      uses 'bash ./sample_script.sh'
+    }
+
+    commandJob('shellPwd') {
+      uses 'pwd'
+    }
+
+    commandJob('shellEcho') {
+      uses 'echo "This is an echoed text."'
+    }
+
+    targets 'shellPwd', 'shellEcho', 'shellBash'
+  }
+}

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -334,7 +334,9 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     Map yamlizedTrigger = [:];
 
     // Add maximum number of minutes the trigger will wait before it's automatically cancelled
-    yamlizedTrigger["maxWaitMins"] = trigger.maxWaitMins;
+    if(trigger.maxWaitMins != 0) {
+      yamlizedTrigger["maxWaitMins"] = trigger.maxWaitMins;
+    }
     // Add trigger schedule
     yamlizedTrigger["schedule"] = yamlizeSchedule(trigger.schedules[0]);
     // Add trigger dependencies if there are any


### PR DESCRIPTION
When a flow trigger contains no dependencies, max wait mins won't be required, and the resulting flow yaml file should not contain max wait mins when it's not defined on DSL side. 