### PR TITLE
LIHADOOP-43954: Rename TensorFlowTonyJob to TonyJob, add "tonyJob" to Hadoop DSL

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.15.0
+* Renamed TensorFlowTonyJob to TonyJob and add "tonyJob" to Hadoop DSL
+
 0.14.35
 * Stop outputting max wait mins when it's defined in a flow trigger with no dependencies
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.14.35
+version=0.15.0

--- a/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job25a.job
+++ b/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job25a.job
@@ -1,10 +1,7 @@
 # This file generated from the Hadoop DSL. Do not edit by hand.
 type=TonyJob
-dependencies=jobs1_job23
+dependencies=jobs1_job25
 executes=path/to/python/script.py
-tony.am.gpus=1
-tony.am.memory=2g
-tony.am.vcores=1
 tony.ps.instances=2
 tony.ps.memory=2g
 tony.ps.vcores=1
@@ -12,5 +9,3 @@ tony.worker.gpus=2
 tony.worker.instances=4
 tony.worker.memory=8g
 tony.worker.vcores=1
-worker_env.ENV1=val1
-worker_env.ENV2=val2

--- a/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job26.job
+++ b/hadoop-plugin-test/expectedJobs/jobs1/jobs1_job26.job
@@ -1,6 +1,6 @@
 # This file generated from the Hadoop DSL. Do not edit by hand.
 type=WormholePushJob
-dependencies=jobs1_job25
+dependencies=jobs1_job25a
 dataset=model
 input.path=/user/input
 namespace=linkedin

--- a/hadoop-plugin-test/src/main/gradle/negative/missingFields.gradle
+++ b/hadoop-plugin-test/src/main/gradle/negative/missingFields.gradle
@@ -123,8 +123,12 @@ hadoop {
       depends 'job24'
     }
 
-    wormholePushJob('job26') {
+    tonyJob('job25a') {
       depends 'job25'
+    }
+
+    wormholePushJob('job26') {
+      depends 'job25a'
     }
     targets 'job26'
   }

--- a/hadoop-plugin-test/src/main/gradle/positive/jobs1.gradle
+++ b/hadoop-plugin-test/src/main/gradle/positive/jobs1.gradle
@@ -420,6 +420,20 @@ hadoop {
       depends 'job24'
     }
 
+    tonyJob('job25a') {
+      set properties: [
+        'executes': 'path/to/python/script.py',
+        'tony.ps.vcores': 1,
+        'tony.ps.memory': '2g',
+        'tony.ps.instances': 2,
+        'tony.worker.vcores': 1,
+        'tony.worker.memory': '8g',
+        'tony.worker.gpus': 2,
+        'tony.worker.instances': 4,
+      ]
+      depends 'job25'
+    }
+
     wormholePushJob('job26') {
       fromInputPath '/user/input'            // Required
       toNamespace 'linkedin'                 // Required
@@ -428,7 +442,7 @@ hadoop {
       preserveInput true                     // Optional
       toOutputLocation 'LOCAL'               // Optional
 
-      depends 'job25'
+      depends 'job25a'
     }
     targets 'job26'
   }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
@@ -35,8 +35,8 @@ import com.linkedin.gradle.hadoopdsl.job.SqlJob;
 import com.linkedin.gradle.hadoopdsl.job.TableauJob;
 import com.linkedin.gradle.hadoopdsl.job.TensorFlowJob
 import com.linkedin.gradle.hadoopdsl.job.TensorFlowSparkJob
-import com.linkedin.gradle.hadoopdsl.job.TensorFlowTonyJob;
-import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob;
+import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob
+import com.linkedin.gradle.hadoopdsl.job.TonyJob;
 import com.linkedin.gradle.hadoopdsl.job.VenicePushJob;
 import com.linkedin.gradle.hadoopdsl.job.VoldemortBuildPushJob;
 import com.linkedin.gradle.hadoopdsl.job.WormholePushJob;
@@ -1109,11 +1109,16 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
     case "spark":
       return ((TensorFlowSparkJob)configureJob(factory.makeTensorFlowSparkJob(name), configure));
     case "tony":
-      return ((TensorFlowTonyJob)configureJob(factory.makeTensorFlowTonyJob(name), configure));
+      return ((TonyJob)configureJob(factory.makeTensorFlowTonyJob(name), configure));
     default:
       throw new Exception("Unsupported execution type: ${type} in TensorFlow job declaration." +
               " Should be SPARK or TONY.");
     }
+  }
+
+  @HadoopDslMethod
+  TonyJob tonyJob(String name, @DelegatesTo(TonyJob) Closure configure) {
+    return ((TonyJob)configureJob(factory.makeTonyJob(name), configure));
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/BaseNamedScopeContainer.groovy
@@ -1116,6 +1116,12 @@ abstract class BaseNamedScopeContainer implements NamedScopeContainer {
     }
   }
 
+  /**
+   * DSL tonyJob method. Creates a TonyJob in scope with the given name and configuration.
+   * @param name The job name
+   * @param configure The configuration closure
+   * @return The new job
+   */
   @HadoopDslMethod
   TonyJob tonyJob(String name, @DelegatesTo(TonyJob) Closure configure) {
     return ((TonyJob)configureJob(factory.makeTonyJob(name), configure));

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslFactory.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslFactory.groovy
@@ -38,8 +38,8 @@ import com.linkedin.gradle.hadoopdsl.job.SubFlowJob;
 import com.linkedin.gradle.hadoopdsl.job.TableauJob;
 import com.linkedin.gradle.hadoopdsl.job.TensorFlowJob
 import com.linkedin.gradle.hadoopdsl.job.TensorFlowSparkJob
-import com.linkedin.gradle.hadoopdsl.job.TensorFlowTonyJob;
-import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob;
+import com.linkedin.gradle.hadoopdsl.job.TeradataToHdfsJob
+import com.linkedin.gradle.hadoopdsl.job.TonyJob;
 import com.linkedin.gradle.hadoopdsl.job.VenicePushJob;
 import com.linkedin.gradle.hadoopdsl.job.VoldemortBuildPushJob;
 import com.linkedin.gradle.hadoopdsl.job.WormholePushJob;
@@ -327,13 +327,24 @@ class HadoopDslFactory {
   }
 
   /**
-   * Factory method to build a TensorFlowTonyJob
+   * @deprecated  Please use {@link #makeTonyJob} instead.
    *
    * @param name The job name
    * @return The job
    */
+  @Deprecated
   TensorFlowJob makeTensorFlowTonyJob(String name) {
-    return new TensorFlowTonyJob(name);
+    return new TonyJob(name);
+  }
+
+  /**
+   * Factory method to build a TonyJob
+   *
+   * @param name The job name
+   * @return The job
+   */
+  TensorFlowJob makeTonyJob(String name) {
+    return new TonyJob(name);
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/HadoopDslPlugin.groovy
@@ -136,6 +136,7 @@ class HadoopDslPlugin extends BaseNamedScopeContainer implements Plugin<Project>
     project.extensions.add("voldemortBuildPushJob", this.&voldemortBuildPushJob);
     project.extensions.add("wormholePushJob", this.&wormholePushJob);
     project.extensions.add("tensorFlowJob", this.&tensorFlowJob);
+    project.extensions.add("tonyJob", this.&tonyJob);
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/TonyJob.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/hadoopdsl/job/TonyJob.groovy
@@ -21,11 +21,11 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 
 /**
- * Job class for type=TensorFlowJob jobs.
+ * Job class for type=TonyJob and type=TensorFlowJob (deprecated) jobs.
  * <p>
- * In the DSL, a TensorFlowJob using TonY can be specified with:
+ * In the DSL, a TonyJob can be specified with:
  * <pre>
- *   tensorFlowJob('jobName', 'tony') {
+ *   tonyJob('jobName') {
  *     def taskParams = [
  *       "--tensorboard",
  *       "--hdfs_input_path /tmp/trainingInput",
@@ -35,11 +35,8 @@ import org.gradle.api.logging.Logging;
  *     ].join(' ')
  *     set properties: [
  *       'python_binary_path': 'Python-2.7.11/bin/python',
- *       'python_venv': "tensorflow-starter-kit-1.4.16-SNAPSHOT-venv.zip",
+ *       'python_venv': "my-venv.zip",
  *       'task_params': taskParams,
- *       'tony.am.memory': '2g',
- *       'tony.am.vcores': 1,
- *       'tony.am.gpus': 1,
  *       'tony.ps.memory': '2g',
  *       'tony.ps.vcores': 1,
  *       'tony.worker.memory': '8g',
@@ -55,10 +52,21 @@ import org.gradle.api.logging.Logging;
  *     ]
  *   }
  * </pre>
+ *
+ * <p>
+ * A TensorFlowJob using TonY (deprecated, please use TonyJob) can be specified with:
+ * <pre>
+ *   tensorFlowJob('jobName', 'tony') {
+ *     def taskParams = [ ... ].join(' ')
+ *     set properties: [ ... ]
+ *     executes path/to/python/script.py
+ *     set workerEnv: [ ... ]
+ *   }
+ * </pre>
  */
-class TensorFlowTonyJob extends HadoopJavaProcessJob implements TensorFlowJob {
+class TonyJob extends HadoopJavaProcessJob implements TensorFlowJob {
 
-  private final static Logger logger = Logging.getLogger(TensorFlowTonyJob);
+  private final static Logger logger = Logging.getLogger(TonyJob);
 
   String executePath;
   String amMemory;
@@ -75,14 +83,14 @@ class TensorFlowTonyJob extends HadoopJavaProcessJob implements TensorFlowJob {
   Map<String, Object> workerEnv;
 
   /**
-   * Constructor for a TensorFlowJob.
+   * Constructor for a TonyJob.
    *
    * @param jobName The job name
    */
-  TensorFlowTonyJob(String jobName) {
+  TonyJob(String jobName) {
     super(jobName);
     workerEnv = new HashMap<>();
-    setJobProperty("type", "TensorFlowJob");
+    setJobProperty("type", "TonyJob");
   }
 
   /**
@@ -91,8 +99,8 @@ class TensorFlowTonyJob extends HadoopJavaProcessJob implements TensorFlowJob {
    * @return The cloned job
    */
   @Override
-  TensorFlowTonyJob clone() {
-    return clone(new TensorFlowTonyJob(name));
+  TonyJob clone() {
+    return clone(new TonyJob(name));
   }
 
   @Override


### PR DESCRIPTION
* Renamed `TensorFlowTonyJob` to `TonyJob` since TonY can run non-TensorFlow jobs, too.
* Added `tonyJob` to the Hadoop DSL. (Still kept `tensorFlowJob('job_name', 'tony')` for backward-compatibility.)