### PR TITLE
Add xmx information to console error message

### DIFF
--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanHelper.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanHelper.groovy
@@ -64,8 +64,11 @@ class AzkabanHelper {
                      |At LinkedIn, you must pass --no-daemon and explicitly set the JAVA_HOME environment variable to
                      |the Java version specified in your product-spec. GRADLE_OPTS environment variable should also be set to
                      |explicitly specify Xmx for Gradle 5 and newer versions, which set a very low default memory threshold for the launcher
-                     |VM; for example: "export GRADLE_OPTS="-Xmx1024m -XX:MaxMetaspaceSize=256m". Refer to the 'Password Masking' section of
-                     |http://go/HadoopPlugin for more info.""".stripMargin();
+                     |VM; for example: "export GRADLE_OPTS="-Xmx1024m -XX:MaxMetaspaceSize=256m".
+                     |Another option for setting Xmx is to set org.gradle.jvmargs in
+                     |gradle.properties. Refer to the 'Password Masking' section of
+                     |https://github.com/linkedin/linkedin-gradle-plugin-for-apache-hadoop/wiki/Azkaban-Features
+                     |for more info.""".stripMargin();
 
   /**
    * Helper method to make a login request to Azkaban.

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanHelper.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanHelper.groovy
@@ -58,6 +58,15 @@ class AzkabanHelper {
 
   private final static Logger logger = Logging.getLogger(AzkabanHelper);
   static String passwordString = "Password";
+  final static String CONSOLE_EXCEPTION_MESSAGE = """Cannot access the system console. Be sure to 
+pass --no-daemon in your command. For more info,
+                     |refer to https://github.com/linkedin/linkedin-gradle-plugin-for-apache-hadoop/wiki/Azkaban-Features#password-masking.
+                     |
+                     |At LinkedIn, you must pass --no-daemon and explicitly set the JAVA_HOME environment variable to
+                     |the Java version specified in your product-spec. GRADLE_OPTS environment variable should also be set to
+                     |explicitly specify Xmx for Gradle 5 and newer versions, which set a very low default memory threshold for the launcher
+                     |VM; for example: "export GRADLE_OPTS="-Xmx1024m -XX:MaxMetaspaceSize=256m". Refer to the 'Password Masking' section of
+                     |http://go/HadoopPlugin for more info.""".stripMargin();
 
   /**
    * Helper method to make a login request to Azkaban.
@@ -315,13 +324,7 @@ class AzkabanHelper {
   static Console getSystemConsole() throws Exception {
     def console = System.console()
     if (console == null) {
-      String msg = """Cannot access the system console. Be sure to pass --no-daemon in your command. For more info,
-                     |refer to https://github.com/linkedin/linkedin-gradle-plugin-for-apache-hadoop/wiki/Azkaban-Features#password-masking.
-                     |
-                     |At LinkedIn, you must pass --no-daemon and explicitly set the JAVA_HOME environment variable to
-                     |the Java version specified in your product-spec. Refer to the 'Password Masking' section of
-                     |http://go/HadoopPlugin for more info.""".stripMargin()
-      throw new Exception(msg)
+      throw new Exception(CONSOLE_EXCEPTION_MESSAGE)
     }
     return console
   }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanHelper.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanHelper.groovy
@@ -58,8 +58,7 @@ class AzkabanHelper {
 
   private final static Logger logger = Logging.getLogger(AzkabanHelper);
   static String passwordString = "Password";
-  final static String CONSOLE_EXCEPTION_MESSAGE = """Cannot access the system console. Be sure to 
-pass --no-daemon in your command. For more info,
+  final static String CONSOLE_EXCEPTION_MESSAGE = """Cannot access the system console. Be sure to pass --no-daemon in your command. For more info,
                      |refer to https://github.com/linkedin/linkedin-gradle-plugin-for-apache-hadoop/wiki/Azkaban-Features#password-masking.
                      |
                      |At LinkedIn, you must pass --no-daemon and explicitly set the JAVA_HOME environment variable to

--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanHelperTest.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanHelperTest.groovy
@@ -20,12 +20,9 @@ import org.json.JSONObject
 import org.junit.Rule;
 import org.junit.Test
 import org.junit.rules.ExpectedException
-import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
-//import org.powermock.modules.junit4.PowerMockRunner;
 
-//@RunWith(PowerMockRunner)
 class AzkabanHelperTest {
   @Test
   public void TestFetchSortedFlows() {

--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanHelperTest.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanHelperTest.groovy
@@ -16,10 +16,16 @@
 package com.linkedin.gradle.azkaban;
 
 import org.gradle.api.GradleException;
-import org.json.JSONObject;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.json.JSONObject
+import org.junit.Rule;
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
+//import org.powermock.modules.junit4.PowerMockRunner;
+
+//@RunWith(PowerMockRunner)
 class AzkabanHelperTest {
   @Test
   public void TestFetchSortedFlows() {
@@ -30,5 +36,15 @@ class AzkabanHelperTest {
   @Test(expected = GradleException.class)
   public void TestGradleException() {
     AzkabanHelper.fetchSortedFlows(new JSONObject("{\"project\" : \"test-azkaban\",   \"projectId\" : 192,   \"flows\" : [ ] }"));
+  }
+
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  @Test(expected = Exception.class)
+  public void TestGetConsoleException() throws Exception {
+    expectedEx.expec(Exception.class);
+    expectedEx.expectMessage(AzkabanHelper.CONSOLE_EXCEPTION_MESSAGE);
+    AzkabanHelper.getSystemConsole();
   }
 }


### PR DESCRIPTION
With Gradle 5, the default xmx is very low. Add a message with instructions to set explicitly for newer versions of Gradle, if there is an exception when getting the console.