### PR TITLE
Add a workaround to handle visiting files multiple times when merging tempprops into .flow files.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -163,3 +163,6 @@ The following were contributed by Jamie Sun. Thanks, Jamie!
 The following were contributed by Rakesh Malladi. Thanks, Rakesh!
 * `Add ability for Hadoop DSL to understand the WormholePushJob job type`
 * `Deprecate dataset.group property from the WormholePushJob`
+
+The following were contributed by Yeni Bermudez. Thanks, Yeni!
+* `Add a workaround to handle visiting files multiple times when merging tempprops into .flow files.`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,9 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.15.7
+* Add a workaround to handle visiting files multiple times when merging tempprops into .flow files.
+
 0.15.3
 * Empty commit to bump version 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.15.6
+version=0.15.7


### PR DESCRIPTION
The [visit](https://docs.gradle.org/current/javadoc/org/gradle/api/file/FileTree.html#visit-org.gradle.api.Action-) function from Gradle in HadoopZipExtension.mergeTempPropsWithFlowFiles() visits files multiple times. This causes the error below when trying to create a merge file it already created on a previous visit to the same file and marked it as read only.

```
Caused by: java.io.FileNotFoundException:/Users/ypadron/azkaban/myProject/aFlow.flow (Permission denied)
        at com.linkedin.gradle.zip.YamlMerge.merge(YamlMerge.groovy:42)
        at com.linkedin.gradle.zip.YamlMerge$merge$0.call(Unknown Source)
        at com.linkedin.gradle.zip.HadoopZipExtension$_mergeTempPropsWithFlowFiles_closure4.doCall(HadoopZipExtension.groovy:247)
        ... 55 more
```

Because the root cause of the issue is in code we don’t control the best option is to implement a workaround to handle the multiple visits.