### PR TITLE
Sort config

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -169,3 +169,6 @@ The following were contributed by Yeni Bermudez. Thanks, Yeni!
 
 The following were contributed by Abhishek Nimesh. Thanks, Abhishek!
 * `Add ability for Hadoop DSL to understand the KabootarJob job type`
+
+The following were contributed by Zhixiong Chen.
+* `Sort config`

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,6 +17,8 @@ the License.
 Note that the LinkedIn build system occasionally requires that we skip a
 version bump, so you will see a few skipped version numbers in the list below.
 
+0.15.9
+* Sort config.
 
 0.15.8
 * Adding KabootarJob job type support

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=true
-version=0.15.8
+version=0.15.9

--- a/hadoop-plugin-test/expectedJobs/flowWithVariableSubstitution/wordCountFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/flowWithVariableSubstitution/wordCountFlow.flow
@@ -18,12 +18,12 @@ nodes:
   - uploadResourceFilesJob
   condition: ${uploadResourceFilesJob:param1} == "foo"
   config:
-    job.class: com.linkedin.hadoop.example.WordCountJob
     classpath: ./lib/*
-    input.path: ./text
-    output.path: ./word-count-map-reduce
-    hadoop-inject.mapreduce.job.classloader: 'true'
     force.output.overwrite: 'true'
+    hadoop-inject.mapreduce.job.classloader: 'true'
+    input.path: ./text
+    job.class: com.linkedin.hadoop.example.WordCountJob
+    output.path: ./word-count-map-reduce
 - name: uploadResourceFilesJob
   type: hadoopShell
   config:

--- a/hadoop-plugin-test/expectedJobs/loadPropsFlow/loadPropsFlow.flow
+++ b/hadoop-plugin-test/expectedJobs/loadPropsFlow/loadPropsFlow.flow
@@ -1,9 +1,9 @@
 config:
+  props1: shared1
+  props2: shared2
   props3: moo3
   props4: moo4
   props5: moo5
-  props1: shared1
-  props2: shared2
   props6: shared6
 nodes:
 - name: loadPropsFlow
@@ -19,10 +19,10 @@ nodes:
 - name: job2
   type: noop
   config:
-    props4: shared4
-    props8: shared8
     props2: job2
+    props4: shared4
     props7: job7
+    props8: shared8
 - name: innerflow
   type: flow
   dependsOn:

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -266,7 +266,7 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     // Add configs if there are any
     Map<String, String> config = buildWorkflowConfig(workflow, isSubflow);
     if (!config.isEmpty()) {
-      yamlizedWorkflow["config"] = config;
+      yamlizedWorkflow["config"] = config.sort();
     }
     // Add jobs and subflows in one item - nodes - if there are any
     List nodes = buildNodes(workflow);
@@ -312,7 +312,7 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
       // Without toString(), it can cause incompatible issue when writing the GString directly
       // to YAML file.
       config.each { key, val -> config[key] = val.toString()};
-      yamlizedJob["config"] = config;
+      yamlizedJob["config"] = config.sort();
     }
 
     return yamlizedJob;

--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
@@ -103,8 +103,9 @@ class AzkabanDslYamlCompilerTest {
   @Test
   public void TestComplicatedYamlWorkflow() {
     Properties props = new Properties("testProperties");
-    props.setJobProperty("configKey1", "configVal1");
     props.setJobProperty("configKey2", "configVal2");
+    props.setJobProperty("configKey1", "configVal1");
+    props.setJobProperty("configKey3", "configValue3");
     when(mockWorkflow.properties).thenReturn([props]);
     when(mockWorkflow.jobsToBuild).thenReturn([mockJob]);
     when(mockWorkflow.flowsToBuild).thenReturn([mockSubflow]);
@@ -113,7 +114,9 @@ class AzkabanDslYamlCompilerTest {
     assertFalse(yamlizedWorkflow.containsKey("name"));
     assertFalse(yamlizedWorkflow.containsKey("type"));
     assertFalse(yamlizedWorkflow.containsKey("dependsOn"));
-    assertEquals(["configKey1": "configVal1", "configKey2": "configVal2"], yamlizedWorkflow["config"]);
+    // Verify sorted config
+    assertEquals(yamlizedWorkflow["config"].toString(),
+        "[configKey1:configVal1, configKey2:configVal2, configKey3:configValue3]");
 
     List sortedNodes = ((List) yamlizedWorkflow["nodes"]).sort();
     Map yamlizedSubflow = (Map) sortedNodes[0];
@@ -262,14 +265,17 @@ class AzkabanDslYamlCompilerTest {
   @Test
   public void TestComplicatedYamlJob() {
     when(mockJob.dependencyNames).thenReturn(["dependency1", "dependency2"].toSet());
-    when(mockJob.buildProperties(yamlCompiler.parentScope)).thenReturn(["configKey1" : "configVal1",
-                                                                        "configKey2": "configVal2"]);
+    when(mockJob.buildProperties(yamlCompiler.parentScope)).thenReturn(["configKey2": "configVal2",
+                                                                        "configKey1" : "configVal1",
+                                                                        "configKey3": "configVal3"]);
 
     Map yamlizedJob = yamlCompiler.yamlizeJob(mockJob);
     assertEquals("testJob", yamlizedJob["name"]);
     assertEquals("testJobtype", yamlizedJob["type"]);
     assertEquals(["dependency1", "dependency2"], ((List) yamlizedJob["dependsOn"]).sort());
-    assertEquals(["configKey1": "configVal1", "configKey2": "configVal2"], yamlizedJob["config"]);
+    // Verify sorted config
+    assertEquals(yamlizedJob["config"].toString(),
+        "[configKey1:configVal1, configKey2:configVal2, configKey3:configVal3]");
   }
 
   @Test

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanDslYamlCompiler.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanDslYamlCompiler.groovy
@@ -71,7 +71,7 @@ class LiAzkabanDslYamlCompiler extends AzkabanDslYamlCompiler {
       filteredConfig[key] = config[key].toString();
     }
     if (!filteredConfig.isEmpty()) {
-      yamlizedJob["config"] = filteredConfig;
+      yamlizedJob["config"] = filteredConfig.sort();
     }
 
     return yamlizedJob;

--- a/li-hadoop-plugin/src/test/groovy/com/linkedin/gradle/liazkaban/yaml/YamlBangBangJobTest.groovy
+++ b/li-hadoop-plugin/src/test/groovy/com/linkedin/gradle/liazkaban/yaml/YamlBangBangJobTest.groovy
@@ -22,7 +22,8 @@ import org.gradle.api.Project;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,8 +40,12 @@ class YamlBangBangJobTest {
     when(mockLiBangBangJob.jobProperties).thenReturn(["type": "hadoopShell"]);
     when(mockLiBangBangJob.dependencyNames).thenReturn([].toSet());
     when(mockLiBangBangJob.condition).thenReturn("one_success");
-    when(mockLiBangBangJob.buildProperties(mockNamedScope)).thenReturn(["type": "hadoopShell"]);
-
+    when(mockLiBangBangJob.buildProperties(mockNamedScope)).thenReturn([
+        "type": "hadoopShell",
+        "configKey2": "configValue2",
+        "configKey1": "configValue1",
+        "configKey3": "configValue3",
+    ]);
     Map yamlizedJob = liYamlCompiler.yamlizeJob(mockLiBangBangJob);
     assertEquals("test", yamlizedJob["name"]);
     assertEquals("hadoopShell", yamlizedJob["type"]);
@@ -53,5 +58,11 @@ class YamlBangBangJobTest {
             "-Dazkaban.link.attempt.url=\${azkaban.link.attempt.url} " +
             "-Dazkaban.job.innodes=\${azkaban.job.innodes} ",
             yamlizedJob["config"]["env.PIG_JAVA_OPTS"]);
+
+    assertNotNull(yamlizedJob["config"].get("env.PIG_JAVA_OPTS"))
+    yamlizedJob["config"].remove("env.PIG_JAVA_OPTS")
+    // Verify sorted older
+    assertEquals(yamlizedJob["config"].toString(),
+        "[configKey1:configValue1, configKey2:configValue2, configKey3:configValue3]")
   }
 }


### PR DESCRIPTION
Currently, configurations in `config` section is unordered. It creates the difficulty to check the difference between 2 versions of the same job. The change is to sort the configurations on alphanumeric ordering over the keys.