### PR TITLE
Refactor AzkabanHelper to avoid System#console calls

### DIFF
--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCancelFlowTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCancelFlowTask.groovy
@@ -50,7 +50,7 @@ class AzkabanCancelFlowTask extends DefaultTask {
    */
   void cancelRunningAzkabanFlow(String sessionId) {
     // Fetch the project flows
-    sessionId = AzkabanHelper.resumeOrGetSession(sessionId, azkProject);
+    sessionId = AzkabanHelper.resumeOrGetSession(sessionId, azkProject, project)
     String fetchFlowsResponse = AzkabanClient.fetchProjectFlows(azkProject.azkabanUrl, azkProject.azkabanProjName, sessionId);
 
     if (fetchFlowsResponse.toLowerCase().contains("error")) {
@@ -103,8 +103,7 @@ class AzkabanCancelFlowTask extends DefaultTask {
       printStatus(flows, responseList);
 
       // Get exec ID's to kill
-      def console = AzkabanHelper.getSystemConsole();
-      String input = AzkabanHelper.consoleInput(console, " > Enter ID's of executions to be killed: ", true);
+      String input = AzkabanHelper.consoleInput(project, " > Enter ID's of executions to be killed: ")
 
       if (input.isEmpty()) {
         logger.error("Nothing entered, exiting...");

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCreateProjectTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanCreateProjectTask.groovy
@@ -46,12 +46,11 @@ class AzkabanCreateProjectTask extends DefaultTask {
    * @param sessionId The Azkaban session ID. If this is null, an attempt will be made to login to Azkaban.
    */
   void createAzkabanProject(String sessionId) {
-    sessionId = AzkabanHelper.resumeOrGetSession(sessionId, azkProject);
+    sessionId = AzkabanHelper.resumeOrGetSession(sessionId, azkProject, project)
 
-    def console = AzkabanHelper.getSystemConsole();
-    String input = AzkabanHelper.consoleInput(console, " > Enter Azkaban project description: ", true);
+    String input = AzkabanHelper.consoleInput(project, " > Enter Azkaban project description: ")
     while (input.isEmpty()) {
-      input = AzkabanHelper.consoleInput(console, "Enter non-empty Azkaban project description: ", false);
+      input = AzkabanHelper.consoleInput(project, "Enter non-empty Azkaban project description: ")
     }
 
     String response = AzkabanClient.createProject(azkProject.azkabanUrl, azkProject.azkabanProjName, input, sessionId);

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanExecuteFlowTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanExecuteFlowTask.groovy
@@ -48,7 +48,7 @@ class AzkabanExecuteFlowTask extends DefaultTask {
    */
   void executeAzkabanFlow(String sessionId) {
     // Fetch the project flows
-    sessionId = AzkabanHelper.resumeOrGetSession(sessionId, azkProject);
+    sessionId = AzkabanHelper.resumeOrGetSession(sessionId, azkProject, project)
     String fetchFlowsResponse = AzkabanClient.fetchProjectFlows(azkProject.azkabanUrl, azkProject.azkabanProjName, sessionId);
 
     if (fetchFlowsResponse.toLowerCase().contains("error")) {
@@ -102,14 +102,12 @@ class AzkabanExecuteFlowTask extends DefaultTask {
    *
    * @return Set of entered indices corresponding to flows
    */
-  static Set<String> getFlowIndicesInput() {
-    def console = AzkabanHelper.getSystemConsole();
-
-    String input = AzkabanHelper.consoleInput(console, " > Enter indices of flows to be executed > ", true);
+  private Set<String> getFlowIndicesInput() {
+    String input = AzkabanHelper.consoleInput(project, " > Enter indices of flows to be executed > ")
     Set<String> indexSet = new HashSet<String>(Arrays.asList(input.split("\\D+")));
 
     while (!input.trim().length() || indexSet.isEmpty()) {
-      input = AzkabanHelper.consoleInput(console, "> Enter correct indices of flows to be executed > ", true);
+      input = AzkabanHelper.consoleInput(project, "> Enter correct indices of flows to be executed > ")
       indexSet = new HashSet<String>(Arrays.asList(input.split("\\D+")));
     }
 

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanFlowStatusTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanFlowStatusTask.groovy
@@ -52,7 +52,7 @@ class AzkabanFlowStatusTask extends DefaultTask {
    */
   List<String> getSortedFlows(String sessionId) {
     // Fetch the project flows
-    sessionId = AzkabanHelper.resumeOrGetSession(sessionId, azkProject);
+    sessionId = AzkabanHelper.resumeOrGetSession(sessionId, azkProject, project)
     String fetchFlowsResponse = AzkabanClient.fetchProjectFlows(azkProject.azkabanUrl, azkProject.azkabanProjName, sessionId);
 
     if (fetchFlowsResponse.toLowerCase().contains("error")) {

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanUploadTask.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanUploadTask.groovy
@@ -62,7 +62,7 @@ class AzkabanUploadTask extends DefaultTask {
    * @param sessionId The Azkaban session id. If this is null, an attempt will be made to login to Azkaban.
    */
   void authenticateAndUploadToAzkaban(String sessionId) {
-    sessionId = AzkabanHelper.resumeOrGetSession(sessionId, azkProject);
+    sessionId = AzkabanHelper.resumeOrGetSession(sessionId, azkProject, project)
     createProjectAndUpload(sessionId);
   }
 

--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/tests/HelperFunctions.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/tests/HelperFunctions.groovy
@@ -31,7 +31,7 @@ class HelperFunctions {
    */
   static boolean checkExpectedZipFiles(Project project, String zipTaskName, Set<String> expected) {
     def zipTask = project.tasks.findByName(zipTaskName);
-    zipTask.execute();
+    zipTask.execute(); // TODO illegal; blocks Gradle 5 upgrade
     Set<String> actual = new HashSet<String>();
 
     project.zipTree(((Zip)zipTask).archivePath).getFiles().each { file ->


### PR DESCRIPTION
The `azkabanUpload` task relies on System#console calls to receive credentials. This requires user/environment special behavior to disable the Gradle daemon via the GRADLE_OPTS env var, `--no-daemon` CLI or other means.

This PR replaces that behavior with a better option, `project.ant.input`. This leverages Gradle's bundled ant instance to collect input, and should allow the Gradle daemon to be used for building azkaban zips.

...unfortunately I have no idea how to test this :) I'll get in touch with the owners via other means.