### PR TITLE
YamlCompiler: Add the project directory to improve static analysis

### DIFF
--- a/hadoop-plugin/src/integTest/resources/expectedJobs/basicFlow/basicFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/basicFlow/basicFlow.flow
@@ -1,5 +1,6 @@
 config:
   flow-level-parameter: value
+  projectDirectory: ''
 nodes:
 - name: basicFlow
   type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/basicFlowMultiple/basicFlow1.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/basicFlowMultiple/basicFlow1.flow
@@ -1,5 +1,6 @@
 config:
   flow-level-parameter: value
+  projectDirectory: ''
 nodes:
 - name: basicFlow1
   type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/basicFlowMultiple/basicFlow2.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/basicFlowMultiple/basicFlow2.flow
@@ -1,5 +1,6 @@
 config:
   flow-level-parameter: value
+  projectDirectory: ''
 nodes:
 - name: basicFlow2
   type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/cloneJobWithCondition/workflow1.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/cloneJobWithCondition/workflow1.flow
@@ -1,3 +1,5 @@
+config:
+  projectDirectory: ''
 nodes:
 - name: workflow1
   type: noop
@@ -20,6 +22,8 @@ nodes:
   dependsOn:
   - shellPwd
   condition: one_failed
+  config:
+    projectDirectory: ''
   nodes:
   - name: embeddedFlow
     type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/conditionalFlow/conditionalFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/conditionalFlow/conditionalFlow.flow
@@ -1,5 +1,6 @@
 config:
   flow-level-parameter: value
+  projectDirectory: ''
 nodes:
 - name: conditionalFlow
   type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/embeddedConditionalFlow/embeddedConditionalFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/embeddedConditionalFlow/embeddedConditionalFlow.flow
@@ -1,5 +1,6 @@
 config:
   flow-level-parameter: value
+  projectDirectory: ''
 nodes:
 - name: embeddedConditionalFlow
   type: noop
@@ -19,6 +20,8 @@ nodes:
   - shellBash
   - shellPwd
   condition: one_success
+  config:
+    projectDirectory: ''
   nodes:
   - name: embeddedFlow
     type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/embeddedFlow/embeddedFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/embeddedFlow/embeddedFlow.flow
@@ -1,5 +1,6 @@
 config:
   flow-level-parameter: value
+  projectDirectory: ''
 nodes:
 - name: embeddedFlow
   type: noop
@@ -19,6 +20,7 @@ nodes:
   type: flow
   config:
     flow-level-parameter: value
+    projectDirectory: ''
   nodes:
   - name: embeddedFlow1
     type: noop
@@ -39,6 +41,7 @@ nodes:
     - shellBash
     config:
       flow-level-parameter: value
+      projectDirectory: ''
     nodes:
     - name: embeddedFlow2
       type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/embeddedFlowWithBaseProperties/embeddedFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/embeddedFlowWithBaseProperties/embeddedFlow.flow
@@ -1,3 +1,5 @@
+config:
+  projectDirectory: ''
 nodes:
 - name: embeddedFlow
   type: noop
@@ -5,6 +7,8 @@ nodes:
   - embeddedFlow1
 - name: embeddedFlow1
   type: flow
+  config:
+    projectDirectory: ''
   nodes:
   - name: embeddedFlow1
     type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/emergentFlow/emergentFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/emergentFlow/emergentFlow.flow
@@ -1,5 +1,6 @@
 config:
   flow-level-parameter: value
+  projectDirectory: ''
 nodes:
 - name: emergentFlow
   type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/flowWithVariableSubstitution/wordCountFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/flowWithVariableSubstitution/wordCountFlow.flow
@@ -1,4 +1,5 @@
 config:
+  projectDirectory: ''
   user.to.proxy: foo
 nodes:
 - name: wordCountFlow
@@ -33,6 +34,8 @@ nodes:
   type: flow
   dependsOn:
   - uploadResourceFilesJob
+  config:
+    projectDirectory: ''
   nodes:
   - name: embeddedFlow
     type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/generateYamlOutputTwice/basicFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/generateYamlOutputTwice/basicFlow.flow
@@ -1,5 +1,6 @@
 config:
   flow-level-parameter: value
+  projectDirectory: ''
 nodes:
 - name: basicFlow
   type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/loadPropsFlow/loadPropsFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/loadPropsFlow/loadPropsFlow.flow
@@ -1,4 +1,5 @@
 config:
+  projectDirectory: ''
   props1: shared1
   props2: shared2
   props3: moo3
@@ -28,6 +29,7 @@ nodes:
   dependsOn:
   - job2
   config:
+    projectDirectory: ''
     props5: innerflow5
     props6: innerflow6
     props8: innerflow8

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/namespacedFlows/basicFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/namespacedFlows/basicFlow.flow
@@ -1,5 +1,6 @@
 config:
   flow-level-parameter: value
+  projectDirectory: ''
 nodes:
 - name: basicFlow
   type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/triggerFlow/triggerFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/triggerFlow/triggerFlow.flow
@@ -21,6 +21,7 @@ trigger:
       unit: hourly
 config:
   flow-level-parameter: value
+  projectDirectory: ''
 nodes:
 - name: triggerFlow
   type: noop

--- a/hadoop-plugin/src/integTest/resources/expectedJobs/triggerFlowWithoutDep/triggerFlow.flow
+++ b/hadoop-plugin/src/integTest/resources/expectedJobs/triggerFlowWithoutDep/triggerFlow.flow
@@ -4,6 +4,7 @@ trigger:
     value: 0 0 1 ? * *
 config:
   flow-level-parameter: value
+  projectDirectory: ''
 nodes:
 - name: triggerFlow
   type: noop

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompiler.groovy
@@ -30,7 +30,10 @@ import com.linkedin.gradle.hadoopdsl.job.SubFlowJob;
 import com.linkedin.gradle.hadoopdsl.triggerDependency.DaliDependency;
 import com.linkedin.gradle.hadoopdsl.triggerDependency.TriggerDependency;
 import org.gradle.api.Project;
-import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.Yaml
+
+import java.nio.file.Path
+import java.nio.file.Paths;
 
 import static com.linkedin.gradle.azkaban.AzkabanConstants.AZK_FLOW_VERSION;
 import static com.linkedin.gradle.util.YamlUtils.setupYamlObject;
@@ -265,9 +268,14 @@ class AzkabanDslYamlCompiler extends BaseCompiler {
     }
     // Add configs if there are any
     Map<String, String> config = buildWorkflowConfig(workflow, isSubflow);
-    if (!config.isEmpty()) {
-      yamlizedWorkflow["config"] = config.sort();
-    }
+
+    // It is useful for static analysis to have the project directory
+    Path rootProjectDirectory = Paths.get(this.project.getRootDir().getAbsolutePath());
+    Path projectDirectory = Paths.get(this.project.getProjectDir().getAbsolutePath());
+    String relativeProjectDir = rootProjectDirectory.relativize(projectDirectory).toString();
+    config.put("projectDirectory", relativeProjectDir);
+    yamlizedWorkflow["config"] = config.sort();
+
     // Add jobs and subflows in one item - nodes - if there are any
     List nodes = buildNodes(workflow);
     if (!nodes.isEmpty()) {

--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanDslYamlCompilerTest.groovy
@@ -79,6 +79,9 @@ class AzkabanDslYamlCompilerTest {
 
     Project mockProject = mock(Project.class);
     when(mockProject.name).thenReturn("test");
+    when(mockProject.getRootDir()).thenReturn(new File("/home/root_directory"))
+    when(mockProject.getProjectDir()).thenReturn(new File("/home/root_directory/project_directory"))
+
     yamlCompiler = new AzkabanDslYamlCompiler(mockProject);
     yamlCompiler.parentScope = mockHadoopScope;
 
@@ -96,7 +99,7 @@ class AzkabanDslYamlCompilerTest {
     assertFalse(yamlizedWorkflow.containsKey("name"));
     assertFalse(yamlizedWorkflow.containsKey("type"));
     assertFalse(yamlizedWorkflow.containsKey("dependsOn"));
-    assertFalse(yamlizedWorkflow.containsKey("config"));
+    assert yamlizedWorkflow.containsKey("config");
     assertFalse(yamlizedWorkflow.containsKey("nodes"));
   }
 
@@ -116,7 +119,7 @@ class AzkabanDslYamlCompilerTest {
     assertFalse(yamlizedWorkflow.containsKey("dependsOn"));
     // Verify sorted config
     assertEquals(yamlizedWorkflow["config"].toString(),
-        "[configKey1:configVal1, configKey2:configVal2, configKey3:configValue3]");
+        "[configKey1:configVal1, configKey2:configVal2, configKey3:configValue3, projectDirectory:project_directory]");
 
     List sortedNodes = ((List) yamlizedWorkflow["nodes"]).sort();
     Map yamlizedSubflow = (Map) sortedNodes[0];
@@ -140,7 +143,7 @@ class AzkabanDslYamlCompilerTest {
     assertEquals("flow", yamlizedSubflow["type"]);
     assertEquals([mockWorkflow.name], yamlizedSubflow["dependsOn"]);
     assertEquals("one_success", yamlizedSubflow["condition"]);
-    assertFalse(yamlizedSubflow.containsKey("config"));
+    assert yamlizedSubflow.containsKey("config");
     assertFalse(yamlizedSubflow.containsKey("nodes"));
   }
 
@@ -156,13 +159,13 @@ class AzkabanDslYamlCompilerTest {
     assertFalse(yamlizedWorkflow.containsKey("name"));
     assertFalse(yamlizedWorkflow.containsKey("type"));
     assertFalse(yamlizedWorkflow.containsKey("dependsOn"));
-    assertEquals(["globalProp1": "val1", "globalProp2": "val2"], yamlizedWorkflow["config"]);
+    assertEquals(["globalProp1": "val1", "globalProp2": "val2", "projectDirectory": "project_directory"], yamlizedWorkflow["config"]);
 
     Map yamlizedSubflow = (Map) ((List) yamlizedWorkflow["nodes"])[0];
     assertEquals("subflowTest", yamlizedSubflow ["name"]);
     assertEquals("flow", yamlizedSubflow["type"]);
     assertEquals([mockWorkflow.name], yamlizedSubflow["dependsOn"]);
-    assertFalse(yamlizedSubflow.containsKey("config"));
+    assert yamlizedSubflow.containsKey("config")
     assertFalse(yamlizedSubflow.containsKey("nodes"));
   }
 
@@ -179,7 +182,7 @@ class AzkabanDslYamlCompilerTest {
     assertFalse(yamlizedWorkflow.containsKey("name"));
     assertFalse(yamlizedWorkflow.containsKey("type"));
     assertFalse(yamlizedWorkflow.containsKey("dependsOn"));
-    assertEquals(["sharedProp": "correctVal"], yamlizedWorkflow["config"]);
+    assertEquals(["sharedProp": "correctVal", "projectDirectory": "project_directory"], yamlizedWorkflow["config"]);
     assertFalse(yamlizedWorkflow.containsKey("nodes"));
   }
 
@@ -203,7 +206,8 @@ class AzkabanDslYamlCompilerTest {
     Map yamlizedWorkflow = yamlCompiler.yamlizeWorkflow(mockWorkflow, false);
     Map expectedConfig = ["workflowProp": "workflowVal",
                           "hadoop-inject.parentProp": "parentVal",
-                          "globalProp": "globalVal"];
+                          "globalProp": "globalVal",
+                          "projectDirectory": "project_directory"];
     assertFalse(yamlizedWorkflow.containsKey("name"));
     assertFalse(yamlizedWorkflow.containsKey("type"));
     assertFalse(yamlizedWorkflow.containsKey("dependsOn"));
@@ -232,7 +236,7 @@ class AzkabanDslYamlCompilerTest {
     assertFalse(yamlizedWorkflow.containsKey("name"));
     assertFalse(yamlizedWorkflow.containsKey("type"));
     assertFalse(yamlizedWorkflow.containsKey("dependsOn"));
-    assertFalse(yamlizedWorkflow.containsKey("config"));
+    assert yamlizedWorkflow.containsKey("config")
     assertEquals(3, ((List) yamlizedWorkflow["nodes"]).size());
 
     List sortedNodes = ((List) yamlizedWorkflow["nodes"]).sort();

--- a/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanDslYamlCompiler.groovy
+++ b/li-hadoop-plugin/src/main/groovy/com/linkedin/gradle/liazkaban/LiAzkabanDslYamlCompiler.groovy
@@ -15,6 +15,9 @@
  */
 package com.linkedin.gradle.liazkaban
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import com.linkedin.gradle.azkaban.AzkabanDslYamlCompiler;
 import com.linkedin.gradle.lihadoopdsl.lijob.LiPigBangBangJob;
 import org.gradle.api.Project
@@ -65,6 +68,13 @@ class LiAzkabanDslYamlCompiler extends AzkabanDslYamlCompiler {
     // Remove type and dependencies from config because they're represented elsewhere
     config.remove("type");
     config.remove("dependencies");
+
+    // It is useful for static analysis to have the project directory
+    Path rootProjectDirectory = Paths.get(this.project.getRootDir().getAbsolutePath());
+    Path projectDirectory = Paths.get(this.project.getProjectDir().getAbsolutePath());
+    String relativeProjectDir = rootProjectDirectory.relativize(projectDirectory).toString();
+    config.put("projectDirectory", relativeProjectDir);
+
     writeGradleForBangBangJob(job, this.project, this.parentScope, this.parentDirectory);
     List<String> filteredKeys = addBangBangProperties(config);
     filteredKeys.each { key ->

--- a/li-hadoop-plugin/src/test/groovy/com/linkedin/gradle/liazkaban/yaml/YamlBangBangJobTest.groovy
+++ b/li-hadoop-plugin/src/test/groovy/com/linkedin/gradle/liazkaban/yaml/YamlBangBangJobTest.groovy
@@ -31,6 +31,7 @@ class YamlBangBangJobTest {
   @Test
   public void TestYamlBangBangJob() {
     Project mockProject = mock(Project.class);
+    Project rootProject = mock(Project.class);
     LiAzkabanDslYamlCompiler liYamlCompiler = new LiAzkabanDslYamlCompiler(mockProject);
     liYamlCompiler.parentDirectory = "build/tmp"
     NamedScope mockNamedScope = mock(NamedScope.class);
@@ -46,7 +47,13 @@ class YamlBangBangJobTest {
         "configKey1": "configValue1",
         "configKey3": "configValue3",
     ]);
+    File f = new File("/a/b");
+    when(mockProject.getProjectDir()).thenReturn(f);
+    when(mockProject.getRootProject()).thenReturn(rootProject);
+    when(rootProject.relativeProjectPath("/a/b")).thenReturn("/a");
+
     Map yamlizedJob = liYamlCompiler.yamlizeJob(mockLiBangBangJob);
+    assertEquals("/a", yamlizedJob["config"]["projectDirectory"]);
     assertEquals("test", yamlizedJob["name"]);
     assertEquals("hadoopShell", yamlizedJob["type"]);
     assertFalse(yamlizedJob.containsKey("dependsOn"));
@@ -62,7 +69,8 @@ class YamlBangBangJobTest {
     assertNotNull(yamlizedJob["config"].get("env.PIG_JAVA_OPTS"))
     yamlizedJob["config"].remove("env.PIG_JAVA_OPTS")
     // Verify sorted older
-    assertEquals(yamlizedJob["config"].toString(),
-        "[configKey1:configValue1, configKey2:configValue2, configKey3:configValue3]")
+    assertEquals(
+        "[configKey1:configValue1, configKey2:configValue2, configKey3:configValue3, projectDirectory:/a]",
+        yamlizedJob["config"].toString());
   }
 }


### PR DESCRIPTION
Why: helps with LinkedIn's internal migration

What changed: added a projectDirectory which helps us identify the subproject in a MP

Tests performed: modified unit tests