### PR TITLE
ScmPlugin: Try to generate buildMetaData.json even when scmPlugin is disabled

### DIFF
--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/scm/ScmPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/scm/ScmPlugin.groovy
@@ -27,24 +27,17 @@ import org.gradle.api.tasks.bundling.Zip
 import java.nio.file.Path
 import java.nio.file.Paths;
 
+
 /**
  * ScmPlugin implements features that generate source control management (scm) metadata, in
- * particular for Git and Subversion.
- */
+ * particular for Git and Subversion.*/
 class ScmPlugin implements Plugin<Project> {
-  /**
-   * Applies the ScmPlugin.
-   *
-   * @param project The Gradle project
-   */
-  @Override
-  void apply(Project project) {
-    // Enable users to skip the plugin
-    if (project.hasProperty("disableScmPlugin")) {
-      println("ScmPlugin disabled");
-      return;
-    }
 
+  void applyMetadataTasks(Project project) {
+    if (project.hasProperty("disableScmPluginMetaData")) {
+      println("ScmPlugin buildMetadata.json disabled")
+      return
+    }
     project.tasks.create("buildScmMetadata") {
       description = "Writes SCM metadata about the project to the project's build directory";
       group = "Hadoop Plugin";
@@ -83,7 +76,16 @@ class ScmPlugin implements Plugin<Project> {
         }
       }
     }
+  }
 
+  @Override
+  void apply(Project project) {
+    applyMetadataTasks(project)
+    // Allows users to skip the plugin if they don't want the sources zip (performance improvement)
+    if (project.hasProperty("disableScmPlugin")) {
+      println("ScmPlugin's sources.zip is disabled");
+      return;
+    }
     // We'll create the buildSourceZip task on the root project, so that there is only one sources
     // zip created that can be shared by all projects. Thus, only create the buildSourceZip task on
     // the root project if it hasn't been created already (you will get an exception if you try to

--- a/li-hadoop-plugin/src/integTest/groovy/com/linkedin/gradle/BuildHadoopZips.groovy
+++ b/li-hadoop-plugin/src/integTest/groovy/com/linkedin/gradle/BuildHadoopZips.groovy
@@ -12,58 +12,131 @@ import java.util.zip.ZipFile
 
 class BuildHadoopZips extends Specification {
 
-    @Rule
-    TemporaryFolder tmp = new TemporaryFolder()
+  @Rule
+  TemporaryFolder tmp = new TemporaryFolder()
 
-    def buildDotGradle
-    def settingsDotGradle
-    def gradleDotProperties
-    def dotCrt
+  def buildDotGradle
+  def settingsDotGradle
+  def gradleDotProperties
+  def dotCrt
 
-    def setup() {
-        tmp.create()
-        buildDotGradle = tmp.newFile('build.gradle')
-        settingsDotGradle = tmp.newFile('settings.gradle')
-        gradleDotProperties = tmp.newFile('gradle.properties')
-        dotCrt = tmp.newFile('.crt')
-    }
+  def setup() {
+    tmp.create()
+    buildDotGradle = tmp.newFile('build.gradle')
+    settingsDotGradle = tmp.newFile('settings.gradle')
+    gradleDotProperties = tmp.newFile('gradle.properties')
+    dotCrt = tmp.newFile('.crt')
+  }
 
-    /**
-     * Integration test for including the sources zip and SCM metadata file in the Hadoop zip
-     */
-    def 'verify zip contents'() {
-        given:
-        def projectName = 'build-hadoop-zips'
-        def version = '1.0.0'
-        buildDotGradle << this.class.classLoader.getResource('buildZips/buildZipsCRT.gradle').text
-        settingsDotGradle << """rootProject.name='${projectName}'"""
-        gradleDotProperties << """version=${version}"""
-        dotCrt << '''Test .crt file\n'''
-        GradleRunner runner = GradleRunner.create()
-                .withProjectDir(tmp.root)
-                .withPluginClasspath()
-                .withArguments('buildHadoopZips', '-is')
+  /**
+   * Integration test for including the sources zip and SCM metadata file in the Hadoop zip*/
+  def 'verify zip contents'() {
+    given:
+    def projectName = 'build-hadoop-zips'
+    def version = '1.0.0'
+    buildDotGradle << this.class.classLoader.getResource('buildZips/buildZipsCRT.gradle').text
+    settingsDotGradle << """rootProject.name='${projectName}'"""
+    gradleDotProperties << """version=${version}"""
+    dotCrt << '''Test .crt file\n'''
+    GradleRunner runner = GradleRunner.create()
+        .withProjectDir(tmp.root)
+        .withPluginClasspath()
+        .withArguments('buildHadoopZips', '-is')
 
-        when:
-        BuildResult result = runner.build()
+    when:
+    BuildResult result = runner.build()
 
-        then:
-        result.task(':azkabanHadoopZip').outcome == TaskOutcome.SUCCESS
-        result.task(':CRTHadoopZip').outcome == TaskOutcome.SUCCESS
+    then:
+    result.task(':azkabanHadoopZip').outcome == TaskOutcome.SUCCESS
+    result.task(':CRTHadoopZip').outcome == TaskOutcome.SUCCESS
 
-        // find CRTHadoopZip, assert contains .crt file (build/distributions/build-hadoop-zips-1.0.0.zip)
-        def crtHadoopZip = new File(tmp.root, "build/distributions/${projectName}-${version}.zip")
-        crtHadoopZip.exists()
-        def crtHadoopZipContents = new ZipFile(crtHadoopZip)
-        assert crtHadoopZipContents.getEntry('.crt') != null
+    // find CRTHadoopZip, assert contains .crt file (build/distributions/build-hadoop-zips-1.0.0.zip)
+    def crtHadoopZip = new File(tmp.root, "build/distributions/${projectName}-${version}.zip")
+    crtHadoopZip.exists()
+    def crtHadoopZipContents = new ZipFile(crtHadoopZip)
+    assert crtHadoopZipContents.getEntry('.crt') != null
 
-        // find azkabanHadoopZip, assert contents (build/distributions/build-hadoop-zips-1.0.0-azkaban.zip)
-        //  contents == build.gradle, buildMetadata.json, build-hadoop-zips-1.0.0-sources.zip
-        def azkabanZip = new File(tmp.root, "build/distributions/${projectName}-${version}-azkaban.zip")
-        azkabanZip.exists()
-        def zipFileContents = new ZipFile(azkabanZip)
-        zipFileContents.getEntry('build.gradle') != null
-        zipFileContents.getEntry('buildMetadata.json') != null
-        zipFileContents.getEntry("${projectName}-${version}-sources.zip") != null
-    }
+    // find azkabanHadoopZip, assert contents (build/distributions/build-hadoop-zips-1.0.0-azkaban.zip)
+    //  contents == build.gradle, buildMetadata.json, build-hadoop-zips-1.0.0-sources.zip
+    def azkabanZip = new File(tmp.root, "build/distributions/${projectName}-${version}-azkaban.zip")
+    azkabanZip.exists()
+    def zipFileContents = new ZipFile(azkabanZip)
+    zipFileContents.getEntry('build.gradle') != null
+    zipFileContents.getEntry('buildMetadata.json') != null
+    zipFileContents.getEntry("${projectName}-${version}-sources.zip") != null
+  }
+
+  def 'verify zip contents doesnt include buildMetadata when asked'() {
+    given:
+    def projectName = 'build-hadoop-zips'
+    def version = '1.0.0'
+    buildDotGradle << this.class.classLoader.getResource('buildZips/buildZipsCRT.gradle').text
+    settingsDotGradle << """rootProject.name='${projectName}'"""
+    gradleDotProperties << """version=${version}\ndisableScmPluginMetaData=true\n"""
+    dotCrt << '''Test .crt file\n'''
+    GradleRunner runner = GradleRunner.create()
+        .withProjectDir(tmp.root)
+        .withPluginClasspath()
+        .withArguments('buildHadoopZips', '-is')
+        .forwardOutput()
+        .withDebug(true)
+
+    when:
+    BuildResult result = runner.build()
+
+    then:
+    result.task(':azkabanHadoopZip').outcome == TaskOutcome.SUCCESS
+    result.task(':CRTHadoopZip').outcome == TaskOutcome.SUCCESS
+
+    // find CRTHadoopZip, assert contains .crt file (build/distributions/build-hadoop-zips-1.0.0.zip)
+    def crtHadoopZip = new File(tmp.root, "build/distributions/${projectName}-${version}.zip")
+    crtHadoopZip.exists()
+    def crtHadoopZipContents = new ZipFile(crtHadoopZip)
+    assert crtHadoopZipContents.getEntry('.crt') != null
+
+    // find azkabanHadoopZip, assert contents (build/distributions/build-hadoop-zips-1.0.0-azkaban.zip)
+    //  contents == build.gradle, buildMetadata.json, build-hadoop-zips-1.0.0-sources.zip
+    def azkabanZip = new File(tmp.root, "build/distributions/${projectName}-${version}-azkaban.zip")
+    azkabanZip.exists()
+    def zipFileContents = new ZipFile(azkabanZip)
+    zipFileContents.getEntry('build.gradle') != null
+    zipFileContents.getEntry('buildMetadata.json') == null
+    zipFileContents.getEntry("${projectName}-${version}-sources.zip") != null
+  }
+
+  def 'verify zip contents doesnt include buildMetadata AND sources when asked'() {
+    given:
+    def projectName = 'build-hadoop-zips'
+    def version = '1.0.0'
+    buildDotGradle << this.class.classLoader.getResource('buildZips/buildZipsCRT.gradle').text
+    settingsDotGradle << """rootProject.name='${projectName}'"""
+    gradleDotProperties << """version=${version}\ndisableScmPluginMetaData=true\ndisableScmPlugin=true"""
+    dotCrt << '''Test .crt file\n'''
+    GradleRunner runner = GradleRunner.create()
+        .withProjectDir(tmp.root)
+        .withPluginClasspath()
+        .withArguments('buildHadoopZips', '-is')
+
+    when:
+    BuildResult result = runner.build()
+
+    then:
+    result.task(':azkabanHadoopZip').outcome == TaskOutcome.SUCCESS
+    result.task(':CRTHadoopZip').outcome == TaskOutcome.SUCCESS
+
+    // find CRTHadoopZip, assert contains .crt file (build/distributions/build-hadoop-zips-1.0.0.zip)
+    def crtHadoopZip = new File(tmp.root, "build/distributions/${projectName}-${version}.zip")
+    crtHadoopZip.exists()
+    def crtHadoopZipContents = new ZipFile(crtHadoopZip)
+    assert crtHadoopZipContents.getEntry('.crt') != null
+
+    // find azkabanHadoopZip, assert contents (build/distributions/build-hadoop-zips-1.0.0-azkaban.zip)
+    //  contents == build.gradle, buildMetadata.json, build-hadoop-zips-1.0.0-sources.zip
+    def azkabanZip = new File(tmp.root, "build/distributions/${projectName}-${version}-azkaban.zip")
+    azkabanZip.exists()
+    def zipFileContents = new ZipFile(azkabanZip)
+    zipFileContents.getEntry('build.gradle') != null
+    zipFileContents.getEntry('buildMetadata.json') == null
+    zipFileContents.getEntry("${projectName}-${version}-sources.zip") == null
+  }
 }


### PR DESCRIPTION
People seem to disable scm plugin to improve their zip size/performance.
Changed the flag to two flags to allow metadata.json to be created by
default but for projects where existing flags is set to false, the zip will not be created