### PR TITLE
repeat console input untill non-empty password for azkabanUpload

### DIFF
--- a/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanHelperTest.groovy
+++ b/hadoop-plugin/src/test/groovy/com/linkedin/gradle/azkaban/AzkabanHelperTest.groovy
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.junit.rules.ExpectedException
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*
 
 class AzkabanHelperTest {
   @Test
@@ -44,4 +45,27 @@ class AzkabanHelperTest {
     expectedEx.expectMessage(AzkabanHelper.CONSOLE_EXCEPTION_MESSAGE);
     AzkabanHelper.getSystemConsole();
   }
+
+  // Since Console is final class, it requires `mock-maker-inline` extension to run below test.
+  // More details: https://github.com/mockito/mockito/wiki/What's-new-in-Mockito-2#unmockable
+  // Enabling this extension causes several other test cases failure. Keeping below test case commented for now.
+//  @Test
+//  void testConsoleSecretInput() {
+//    String consoleInputMessage = "Enter test input: "
+//    char[] nonEmptyInput = "test".toCharArray()
+//    char[] emptyInput = "".toCharArray()
+//    Console mockedConsole = mock(Console.class)
+//
+//    when(mockedConsole.readPassword()).thenReturn(nonEmptyInput)
+//    assertEquals(AzkabanHelper.consoleSecretInput(mockedConsole, consoleInputMessage, false, false), nonEmptyInput)
+//
+//    when(mockedConsole.readPassword()).thenReturn(nonEmptyInput)
+//    assertEquals(AzkabanHelper.consoleSecretInput(mockedConsole, consoleInputMessage, false, true), nonEmptyInput)
+//
+//    when(mockedConsole.readPassword()).thenReturn(emptyInput)
+//    assertEquals(AzkabanHelper.consoleSecretInput(mockedConsole, consoleInputMessage, false, false), emptyInput)
+//
+//    when(mockedConsole.readPassword()).thenReturn(emptyInput, emptyInput, nonEmptyInput)
+//    assertEquals(AzkabanHelper.consoleSecretInput(mockedConsole, consoleInputMessage, false, true), nonEmptyInput)
+//  }
 }


### PR DESCRIPTION
**Usecase:**
When user runs `gradle azkabanUpload` command, there are two scenarios that can happen in terms of login:
1. Session already exists: In this case user is required to press enter to resume previous session.
2. Session doesn't exists/expired: In this case user is asked for password. But this step doesn't check for empty password.

Since option 1 happens most of the time and command takes some time to run, user tends to press return key one or more time as soon as command is run. But when session is expired, extra return key causes empty password input and gradle task fails. For projects with complex task dependencies it can take up to 5 minutes to reach password prompt again.



**Solution:**
When password is empty, ask for password again. This way even with extra return keys, user will be still on password prompt.



**Changes:**
- Adding optional boolean argument `retryIfEmpty` for function `consoleSecretInput`  of `com.linkedin.gradle.azkaban.AzkabanHelperTest` class, which is responsible for reading password input.
- Setting default value to `false`, to keep previous behavior if `retryIfEmpty` not specified.


**Testing:**
- Written unittest which succeeds when `mock-maker-inline` extension enabled. This extenstion is required because we need to mock `Console` class which is final class([reference](https://github.com/mockito/mockito/wiki/What's-new-in-Mockito-2#unmockable)). However, adding this extension caused other testcase failures(13 test out of total 49). For now keeping this unit test commented, but I would love to hear comments on this.
- Tested by running `gradle azkabanUpload` command.
